### PR TITLE
Fix flaky test in `test_configuration.py`

### DIFF
--- a/test/e2e/configuration.py
+++ b/test/e2e/configuration.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with Configuration resources"""
+
+import datetime
+import time
+import typing
+
+import boto3
+import pytest
+
+DELETE_WAIT_TIME_TIMEOUT_SECONDS = 60*10
+
+ConfigurationMatchFunc = typing.NewType(
+    'ConfigurationMatchFunc',
+    typing.Callable[[dict], bool],
+)
+
+class StateMatcher:
+    def __init__(self, state):
+        self.match_on = state
+
+    def __call__(self, record: dict) -> bool:
+        return ('State' in record
+                and record['State'] == self.match_on)
+
+
+def state_matches(state: str) -> ConfigurationMatchFunc:
+    return StateMatcher(state)
+
+
+def wait_until_deleted(
+        configuration_arn: str,
+        timeout_seconds: int = DELETE_WAIT_TIME_TIMEOUT_SECONDS,
+        interval_seconds: int = 15,
+    ) -> None:
+    """Waits until a Configuration with a supplied ID is no longer returned from
+    the MSK API.
+
+    Usage:
+        from e2e.configuration import wait_until_deleted
+
+        wait_until_deleted(configuration_name)
+
+    Raises:
+        pytest.fail upon timeout
+    """
+    now = datetime.datetime.now()
+    timeout = now + datetime.timedelta(seconds=timeout_seconds)
+
+    while True:
+        if datetime.datetime.now() >= timeout:
+            pytest.fail(
+                "Timed out waiting for Configuration to be "
+                "deleted in MSK API"
+            )
+        time.sleep(interval_seconds)
+
+        latest = get_by_arn(configuration_arn)
+        if latest is None:
+            break
+
+def get_by_arn(config_arn):
+    c = boto3.client("kafka")
+    try:
+        resp = c.describe_configuration(Arn=config_arn)
+        return resp
+    except c.exceptions.BadRequestException:
+        return None

--- a/test/e2e/tests/test_configuration.py
+++ b/test/e2e/tests/test_configuration.py
@@ -24,20 +24,11 @@ from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
 from e2e.common.types import CONFIG_RESOURCE_PLURAL
 from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.configuration import wait_until_deleted, get_by_arn
 
 CREATE_WAIT_SECONDS = 10
 MODIFY_WAIT_SECONDS = 10
-DELETE_WAIT_SECONDS = 10
-
-
-def get_by_arn(config_arn):
-    c = boto3.client("kafka")
-    try:
-        resp = c.describe_configuration(Arn=config_arn)
-        return resp
-    except c.exceptions.BadRequestException:
-        return None
-
+DELETE_WAIT_SECONDS = 30
 
 @pytest.fixture(scope="module")
 def simple_config():
@@ -105,7 +96,8 @@ class TestConfiguration:
         # delete the CR
         _, deleted = k8s.delete_custom_resource(ref, 2, 5)
         assert deleted
-        time.sleep(DELETE_WAIT_SECONDS)
+        
+        wait_until_deleted(config_arn)
 
         latest = get_by_arn(config_arn)
         assert latest is None


### PR DESCRIPTION
Change `DELETE_WAIT_SECONDS` from 10 to 30 seconds to allow more
time for deletion operations in the e2e tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
