### PR TITLE
Add bootstrap broker string fields to Cluster status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: 619ff4b8739eb9cbf1a2d71d97046be2cb8e1587
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.158
 generator_config_info:
-  file_checksum: da1df5a3919b91ffc472158b5cfd99620b23b6aa
+  file_checksum: a194dbe232ce55c08048ef94e25c993998f5e46a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-08-29T17:08:47Z"
-  build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
-  go_version: go1.22.5
-  version: v0.38.1
-api_directory_checksum: 619ff4b8739eb9cbf1a2d71d97046be2cb8e1587
+  build_date: "2024-10-03T21:01:53Z"
+  build_hash: 9b58156c4d3482ef5175d763efea10e9a4197b69
+  go_version: go1.22.4
+  version: v0.38.1-2-g9b58156
+api_directory_checksum: 8ffc9011fdb39273c403606a87d91dc52e25fcfa
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.158
 generator_config_info:
-  file_checksum: a194dbe232ce55c08048ef94e25c993998f5e46a
+  file_checksum: 8486bf862164f1ccd6dafdede21b7e0df3cbea05
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/cluster.go
+++ b/apis/v1alpha1/cluster.go
@@ -71,6 +71,26 @@ type ClusterStatus struct {
 	// resource
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerString *string `json:"bootstrapBrokerString,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringPublicSASLIAM *string `json:"bootstrapBrokerStringPublicSASLIAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringPublicSASLSCRAM *string `json:"bootstrapBrokerStringPublicSASLSCRAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringPublicTLS *string `json:"bootstrapBrokerStringPublicTLS,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringSASLIAM *string `json:"bootstrapBrokerStringSASLIAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringSASLSCRAM *string `json:"bootstrapBrokerStringSASLSCRAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringTLS *string `json:"bootstrapBrokerStringTLS,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringVPCConnectivitySASLIAM *string `json:"bootstrapBrokerStringVPCConnectivitySASLIAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringVPCConnectivitySASLSCRAM *string `json:"bootstrapBrokerStringVPCConnectivitySASLSCRAM,omitempty"`
+	// +kubebuilder:validation:Optional
+	BootstrapBrokerStringVPCConnectivityTLS *string `json:"bootstrapBrokerStringVPCConnectivityTLS,omitempty"`
 	// The state of the cluster. The possible states are ACTIVE, CREATING, DELETING,
 	// FAILED, HEALING, MAINTENANCE, REBOOTING_BROKER, and UPDATING.
 	// +kubebuilder:validation:Optional

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -26,6 +26,8 @@ resources:
         template_path: hooks/cluster/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/cluster/sdk_delete_pre_build_request.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     update_operation:
       custom_method_name: customUpdate
     synced:
@@ -53,6 +55,36 @@ resources:
         type: string
         is_read_only: true
       ZookeeperConnectStringTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerString:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicSaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicSaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringSaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringSaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivitySaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivitySaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivityTls:
         type: string
         is_read_only: true
     tags:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -51,6 +51,8 @@ resources:
       Tags:
         compare:
           is_ignored: true
+      BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
+        go_tag: json:"type,omitempty"
       ZookeeperConnectString:
         type: string
         is_read_only: true

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -425,7 +425,7 @@ type ProvisionedThroughput struct {
 
 // Broker public access control.
 type PublicAccess struct {
-	Type *string `json:"type_,omitempty"`
+	Type *string `json:"type,omitempty"`
 }
 
 // The details of the Amazon S3 destination for broker logs.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -666,6 +666,56 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			}
 		}
 	}
+	if in.BootstrapBrokerString != nil {
+		in, out := &in.BootstrapBrokerString, &out.BootstrapBrokerString
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringPublicSASLIAM != nil {
+		in, out := &in.BootstrapBrokerStringPublicSASLIAM, &out.BootstrapBrokerStringPublicSASLIAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringPublicSASLSCRAM != nil {
+		in, out := &in.BootstrapBrokerStringPublicSASLSCRAM, &out.BootstrapBrokerStringPublicSASLSCRAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringPublicTLS != nil {
+		in, out := &in.BootstrapBrokerStringPublicTLS, &out.BootstrapBrokerStringPublicTLS
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringSASLIAM != nil {
+		in, out := &in.BootstrapBrokerStringSASLIAM, &out.BootstrapBrokerStringSASLIAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringSASLSCRAM != nil {
+		in, out := &in.BootstrapBrokerStringSASLSCRAM, &out.BootstrapBrokerStringSASLSCRAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringTLS != nil {
+		in, out := &in.BootstrapBrokerStringTLS, &out.BootstrapBrokerStringTLS
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringVPCConnectivitySASLIAM != nil {
+		in, out := &in.BootstrapBrokerStringVPCConnectivitySASLIAM, &out.BootstrapBrokerStringVPCConnectivitySASLIAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringVPCConnectivitySASLSCRAM != nil {
+		in, out := &in.BootstrapBrokerStringVPCConnectivitySASLSCRAM, &out.BootstrapBrokerStringVPCConnectivitySASLSCRAM
+		*out = new(string)
+		**out = **in
+	}
+	if in.BootstrapBrokerStringVPCConnectivityTLS != nil {
+		in, out := &in.BootstrapBrokerStringVPCConnectivityTLS, &out.BootstrapBrokerStringVPCConnectivityTLS
+		*out = new(string)
+		**out = **in
+	}
 	if in.State != nil {
 		in, out := &in.State, &out.State
 		*out = new(string)

--- a/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: clusters.kafka.services.k8s.aws
 spec:
   group: kafka.services.k8s.aws
@@ -40,7 +40,6 @@ spec:
             description: |-
               ClusterSpec defines the desired state of Cluster.
 
-
               Returns information about a cluster of either the provisioned or the serverless
               type.
             properties:
@@ -48,7 +47,7 @@ spec:
                 items:
                   description: "AWSResourceReferenceWrapper provides a wrapper around
                     *AWSResourceReference\ntype to provide more user friendly syntax
-                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                     \ name: my-api"
                   properties:
                     from:
@@ -87,7 +86,7 @@ spec:
                       publicAccess:
                         description: Broker public access control.
                         properties:
-                          type_:
+                          type:
                             type: string
                         type: object
                     type: object
@@ -291,7 +290,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:

--- a/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
@@ -307,6 +307,26 @@ spec:
                 - ownerAccountID
                 - region
                 type: object
+              bootstrapBrokerString:
+                type: string
+              bootstrapBrokerStringPublicSASLIAM:
+                type: string
+              bootstrapBrokerStringPublicSASLSCRAM:
+                type: string
+              bootstrapBrokerStringPublicTLS:
+                type: string
+              bootstrapBrokerStringSASLIAM:
+                type: string
+              bootstrapBrokerStringSASLSCRAM:
+                type: string
+              bootstrapBrokerStringTLS:
+                type: string
+              bootstrapBrokerStringVPCConnectivitySASLIAM:
+                type: string
+              bootstrapBrokerStringVPCConnectivitySASLSCRAM:
+                type: string
+              bootstrapBrokerStringVPCConnectivityTLS:
+                type: string
               conditions:
                 description: |-
                   All CRS managed by ACK have a common `Status.Conditions` member that

--- a/config/crd/bases/kafka.services.k8s.aws_configurations.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_configurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: configurations.kafka.services.k8s.aws
 spec:
   group: kafka.services.k8s.aws
@@ -39,7 +39,6 @@ spec:
           spec:
             description: |-
               ConfigurationSpec defines the desired state of Configuration.
-
 
               Represents an MSK Configuration.
             properties:
@@ -81,7 +80,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list
@@ -22,37 +23,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
   - kafka.services.k8s.aws
   resources:
   - clusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - kafka.services.k8s.aws
-  resources:
-  - clusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - kafka.services.k8s.aws
-  resources:
   - configurations
   verbs:
   - create
@@ -65,6 +38,7 @@ rules:
 - apiGroups:
   - kafka.services.k8s.aws
   resources:
+  - clusters/status
   - configurations/status
   verbs:
   - get
@@ -74,12 +48,6 @@ rules:
   - secretsmanager.services.k8s.aws
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - secretsmanager.services.k8s.aws
-  resources:
   - secrets/status
   verbs:
   - get
@@ -88,25 +56,6 @@ rules:
   - services.k8s.aws
   resources:
   - adoptedresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - services.k8s.aws
-  resources:
-  - adoptedresources/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - services.k8s.aws
-  resources:
   - fieldexports
   verbs:
   - create
@@ -119,6 +68,7 @@ rules:
 - apiGroups:
   - services.k8s.aws
   resources:
+  - adoptedresources/status
   - fieldexports/status
   verbs:
   - get

--- a/generator.yaml
+++ b/generator.yaml
@@ -26,6 +26,8 @@ resources:
         template_path: hooks/cluster/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/cluster/sdk_delete_pre_build_request.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     update_operation:
       custom_method_name: customUpdate
     synced:
@@ -53,6 +55,36 @@ resources:
         type: string
         is_read_only: true
       ZookeeperConnectStringTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerString:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicSaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicSaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringPublicTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringSaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringSaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringTls:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivitySaslIam:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivitySaslScram:
+        type: string
+        is_read_only: true
+      BootstrapBrokerStringVpcConnectivityTls:
         type: string
         is_read_only: true
     tags:

--- a/generator.yaml
+++ b/generator.yaml
@@ -51,6 +51,8 @@ resources:
       Tags:
         compare:
           is_ignored: true
+      BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
+        go_tag: json:"type,omitempty"
       ZookeeperConnectString:
         type: string
         is_read_only: true

--- a/helm/crds/kafka.services.k8s.aws_clusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: clusters.kafka.services.k8s.aws
 spec:
   group: kafka.services.k8s.aws
@@ -40,7 +40,6 @@ spec:
             description: |-
               ClusterSpec defines the desired state of Cluster.
 
-
               Returns information about a cluster of either the provisioned or the serverless
               type.
             properties:
@@ -48,7 +47,7 @@ spec:
                 items:
                   description: "AWSResourceReferenceWrapper provides a wrapper around
                     *AWSResourceReference\ntype to provide more user friendly syntax
-                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                     \ name: my-api"
                   properties:
                     from:
@@ -87,7 +86,7 @@ spec:
                       publicAccess:
                         description: Broker public access control.
                         properties:
-                          type_:
+                          type:
                             type: string
                         type: object
                     type: object
@@ -291,7 +290,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:

--- a/helm/crds/kafka.services.k8s.aws_clusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_clusters.yaml
@@ -307,6 +307,26 @@ spec:
                 - ownerAccountID
                 - region
                 type: object
+              bootstrapBrokerString:
+                type: string
+              bootstrapBrokerStringPublicSASLIAM:
+                type: string
+              bootstrapBrokerStringPublicSASLSCRAM:
+                type: string
+              bootstrapBrokerStringPublicTLS:
+                type: string
+              bootstrapBrokerStringSASLIAM:
+                type: string
+              bootstrapBrokerStringSASLSCRAM:
+                type: string
+              bootstrapBrokerStringTLS:
+                type: string
+              bootstrapBrokerStringVPCConnectivitySASLIAM:
+                type: string
+              bootstrapBrokerStringVPCConnectivitySASLSCRAM:
+                type: string
+              bootstrapBrokerStringVPCConnectivityTLS:
+                type: string
               conditions:
                 description: |-
                   All CRS managed by ACK have a common `Status.Conditions` member that

--- a/helm/crds/kafka.services.k8s.aws_configurations.yaml
+++ b/helm/crds/kafka.services.k8s.aws_configurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: configurations.kafka.services.k8s.aws
 spec:
   group: kafka.services.k8s.aws
@@ -39,7 +39,6 @@ spec:
           spec:
             description: |-
               ConfigurationSpec defines the desired state of Configuration.
-
 
               Represents an MSK Configuration.
             properties:
@@ -81,7 +80,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws
@@ -78,10 +78,8 @@ spec:
                       automatically converts this to an arbitrary string-string map.
                       https://github.com/kubernetes-sigs/controller-tools/issues/385
 
-
                       Active discussion about inclusion of this field in the spec is happening in this PR:
                       https://github.com/kubernetes-sigs/controller-tools/pull/395
-
 
                       Until this is allowed, or if it never is, we will produce a subset of the object meta
                       that contains only the fields which the user is allowed to modify in the metadata.
@@ -105,12 +103,10 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
-
 
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
@@ -139,7 +135,6 @@ spec:
                           equivalent to the "default" namespace, but "default" is the canonical representation.
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
-
 
                           Must be a DNS_LABEL.
                           Cannot be updated.

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -55,6 +55,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list
@@ -69,37 +70,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
   - kafka.services.k8s.aws
   resources:
   - clusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - kafka.services.k8s.aws
-  resources:
-  - clusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - kafka.services.k8s.aws
-  resources:
   - configurations
   verbs:
   - create
@@ -112,6 +85,7 @@ rules:
 - apiGroups:
   - kafka.services.k8s.aws
   resources:
+  - clusters/status
   - configurations/status
   verbs:
   - get
@@ -121,12 +95,6 @@ rules:
   - secretsmanager.services.k8s.aws
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - secretsmanager.services.k8s.aws
-  resources:
   - secrets/status
   verbs:
   - get
@@ -135,25 +103,6 @@ rules:
   - services.k8s.aws
   resources:
   - adoptedresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - services.k8s.aws
-  resources:
-  - adoptedresources/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - services.k8s.aws
-  resources:
   - fieldexports
   verbs:
   - create
@@ -166,6 +115,7 @@ rules:
 - apiGroups:
   - services.k8s.aws
   resources:
+  - adoptedresources/status
   - fieldexports/status
   verbs:
   - get

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -152,6 +152,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           capabilities:
             drop:

--- a/pkg/resource/cluster/delta.go
+++ b/pkg/resource/cluster/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.AssociatedSCRAMSecretRefs, b.ko.Spec.AssociatedSCRAMSecretRefs) {
 		delta.Add("Spec.AssociatedSCRAMSecretRefs", a.ko.Spec.AssociatedSCRAMSecretRefs, b.ko.Spec.AssociatedSCRAMSecretRefs)

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -322,14 +322,16 @@ func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
 	if a.ko.Spec.BrokerNodeGroupInfo.BrokerAZDistribution == nil {
 		a.ko.Spec.BrokerNodeGroupInfo.BrokerAZDistribution = aws.String(svcsdk.BrokerAZDistributionDefault)
 	}
-	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo == nil {
+	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo == nil && b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo != nil {
 		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo = b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo
 	}
-	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess == nil {
-		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess = b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess
-	}
-	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type == nil {
-		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type = aws.String("DISABLED")
+	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo != nil {
+		if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess == nil && b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo != nil {
+			a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess = b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess
+		}
+		if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type == nil {
+			a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type = aws.String("DISABLED")
+		}
 	}
 	if a.ko.Spec.BrokerNodeGroupInfo.SecurityGroups == nil {
 		a.ko.Spec.BrokerNodeGroupInfo.SecurityGroups = b.ko.Spec.BrokerNodeGroupInfo.SecurityGroups
@@ -337,11 +339,13 @@ func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
 	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo == nil {
 		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo
 	}
-	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo == nil {
-		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo
-	}
-	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize == nil {
-		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize
+	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo != nil {
+		if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo == nil {
+			a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo
+		}
+		if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize == nil {
+			a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize
+		}
 	}
 
 	if a.ko.Spec.ClientAuthentication == nil {

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -18,11 +18,13 @@ import (
 	"errors"
 	"fmt"
 
+	svcapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/kafka"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -125,7 +127,6 @@ func (rm *resourceManager) customUpdate(
 	// So we construct the updatedRes object from the desired resource to
 	// obtain correct spec fields and then copy the status from latest.
 	updatedRes := rm.concreteResource(desired.DeepCopy())
-	updatedRes.SetStatus(latest)
 
 	if clusterDeleting(latest) {
 		msg := "Cluster is currently being deleted"
@@ -264,4 +265,98 @@ func (rm *resourceManager) batchDisassociateScramSecret(
 	_, err = rm.sdkapi.BatchDisassociateScramSecretWithContext(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "BatchDisassociateScramSecret", err)
 	return err
+}
+
+// setResourceDefaults queries the MSK Cluster for the current state of the
+// fields that are not returned by the ReadOne or List APIs.
+func (rm *resourceManager) setResourceAdditionalFields(ctx context.Context, r *svcapitypes.Cluster) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setResourceAdditionalFields")
+	defer func() { exit(err) }()
+
+	err = rm.setBootstrapBrokerStringInformations(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setBootstrapBrokerStringInformations sets the bootstrapBrokerString
+// information status fields.
+func (rm *resourceManager) setBootstrapBrokerStringInformations(ctx context.Context, r *svcapitypes.Cluster) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setBootstrapBrokerStringInformations")
+	defer func() { exit(err) }()
+
+	var output *svcsdk.GetBootstrapBrokersOutput
+	output, err = rm.sdkapi.GetBootstrapBrokersWithContext(
+		ctx,
+		&svcsdk.GetBootstrapBrokersInput{
+			ClusterArn: (*string)(r.Status.ACKResourceMetadata.ARN),
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "GetBootstrapBrokers", err)
+	if err != nil {
+		return err
+	}
+
+	r.Status.BootstrapBrokerString = output.BootstrapBrokerString
+	r.Status.BootstrapBrokerStringPublicSASLIAM = output.BootstrapBrokerStringPublicSaslIam
+	r.Status.BootstrapBrokerStringPublicSASLSCRAM = output.BootstrapBrokerStringPublicSaslScram
+	r.Status.BootstrapBrokerStringPublicTLS = output.BootstrapBrokerStringPublicTls
+	r.Status.BootstrapBrokerStringSASLIAM = output.BootstrapBrokerStringSaslIam
+	r.Status.BootstrapBrokerStringSASLSCRAM = output.BootstrapBrokerStringSaslScram
+	r.Status.BootstrapBrokerStringTLS = output.BootstrapBrokerStringTls
+	r.Status.BootstrapBrokerStringVPCConnectivitySASLIAM = output.BootstrapBrokerStringVpcConnectivitySaslIam
+	r.Status.BootstrapBrokerStringVPCConnectivitySASLSCRAM = output.BootstrapBrokerStringVpcConnectivitySaslScram
+	r.Status.BootstrapBrokerStringVPCConnectivityTLS = output.BootstrapBrokerStringVpcConnectivityTls
+	return nil
+}
+
+func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
+	// Set MSK defaults
+	if a.ko.Spec.BrokerNodeGroupInfo == nil {
+		a.ko.Spec.BrokerNodeGroupInfo = b.ko.Spec.BrokerNodeGroupInfo
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.BrokerAZDistribution == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.BrokerAZDistribution = aws.String(svcsdk.BrokerAZDistributionDefault)
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo = b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess = b.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type = aws.String("DISABLED")
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.SecurityGroups == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.SecurityGroups = b.ko.Spec.BrokerNodeGroupInfo.SecurityGroups
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo
+	}
+	if a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize == nil {
+		a.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize = b.ko.Spec.BrokerNodeGroupInfo.StorageInfo.EBSStorageInfo.VolumeSize
+	}
+
+	if a.ko.Spec.ClientAuthentication == nil {
+		a.ko.Spec.ClientAuthentication = b.ko.Spec.ClientAuthentication
+	}
+	if a.ko.Spec.EncryptionInfo == nil {
+		a.ko.Spec.EncryptionInfo = b.ko.Spec.EncryptionInfo
+	}
+	if a.ko.Spec.EnhancedMonitoring == nil {
+		a.ko.Spec.EnhancedMonitoring = aws.String(svcsdk.EnhancedMonitoringDefault)
+	}
+	if a.ko.Spec.OpenMonitoring == nil {
+		a.ko.Spec.OpenMonitoring = b.ko.Spec.OpenMonitoring
+	}
+	if a.ko.Spec.StorageMode == nil {
+		a.ko.Spec.StorageMode = aws.String(svcsdk.StorageModeLocal)
+	}
 }

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -349,6 +349,10 @@ func (rm *resourceManager) sdkFind(
 		if err != nil {
 			return nil, err
 		}
+		err = rm.setResourceAdditionalFields(ctx, ko)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &resource{ko}, nil
 }

--- a/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
@@ -8,4 +8,8 @@
 		if err != nil {
 			return nil, err
 		}
+		err = rm.setResourceAdditionalFields(ctx, ko)
+		if err != nil {
+			return nil, err
+		}
 	}

--- a/test/e2e/cluster.py
+++ b/test/e2e/cluster.py
@@ -23,12 +23,12 @@ import pytest
 # Creating MSK Clusters often takes >25 minutes...
 DEFAULT_WAIT_UNTIL_TIMEOUT_SECONDS = 60 * 35
 DEFAULT_WAIT_UNTIL_INTERVAL_SECONDS = 15
-DEFAULT_WAIT_UNTIL_EXISTS_TIMEOUT_SECONDS = 60 * 10
+DEFAULT_WAIT_UNTIL_EXISTS_TIMEOUT_SECONDS = 60 * 30
 DEFAULT_WAIT_UNTIL_EXISTS_INTERVAL_SECONDS = 15
 # Deleting MSK Clusters often takes >10 minutes if the cluster's dependencies
 # have been deleted already and thus the cluster will transition into a FAILED
 # state.
-DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60 * 15
+DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60 * 30
 DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS = 15
 
 ClusterMatchFunc = typing.NewType(

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -120,6 +120,9 @@ class TestCluster:
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
         condition.assert_synced(ref)
 
+        cr = k8s.get_resource(ref)
+        assert cr['status']['bootstrapBrokerStringSASLSCRAM'] is not None
+
         latest_secrets = cluster.get_associated_scram_secrets(cluster_arn)
         assert len(latest_secrets) == 1
         assert secret_1 in latest_secrets


### PR DESCRIPTION
this commit adds several new fields to the `Cluster` Status
struct to store the bootstrap broker string information for
Amazon MSK clusterss. These fields include:

- `BootstrapBrokerString`
- `BootstrapBrokerStringPublicSASLIAM`
- `BootstrapBrokerStringPublicSASLSCRAM`
- `BootstrapBrokerStringPublicTLS`
- `BootstrapBrokerStringSASLIAM`
- `BootstrapBrokerStringSASLSCRAM`
- `BootstrapBrokerStringTLS`
- `BootstrapBrokerStringVPCConnectivitySASLIAM`
- `BootstrapBrokerStringVPCConnectivitySASLSCRAM`
- `BootstrapBrokerStringVPCConnectivityTLS`

The `setResourceAdditionalFields` function is added to the
resource manager to fetch and set these fields from the AWS
API by calls the `GetBootstrapBrokers` API and populates
the corresponding fields in the ClusterStatus.

additionally, we're adding a `customPreCompar`e hook function
to properly set default values for various Cluster spec fields
before comparing resources during the delta calculation - this
is fixing an observed bug that was impact the status fields

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
