### PR TITLE
Use StorageMode value from API

### DIFF
--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -361,6 +361,6 @@ func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
 		a.ko.Spec.OpenMonitoring = b.ko.Spec.OpenMonitoring
 	}
 	if a.ko.Spec.StorageMode == nil {
-		a.ko.Spec.StorageMode = aws.String(svcsdk.StorageModeLocal)
+		a.ko.Spec.StorageMode = b.ko.Spec.StorageMode
 	}
 }


### PR DESCRIPTION
The default value set for `spec.storageMode` is `null` and not `LOCAL`