### PR TITLE
Release artifacts for release v1.2.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-08-15T00:27:24Z"
-  build_hash: b6df33f8c7f55b234555c0b578b8de43c74771a8
-  go_version: go1.24.6
-  version: v0.51.0
+  build_date: "2025-09-20T19:29:14Z"
+  build_hash: 5bf1e456e1dfc638d47ab492376335f528c0f455
+  go_version: go1.25.0
+  version: v0.52.0-1-g5bf1e45
 api_directory_checksum: 83a6f2d33e6781954a317da21e666cd5195403b7
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/kafka-controller
-  newTag: 1.2.0
+  newTag: 1.2.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.51.0
+	github.com/aws-controllers-k8s/runtime v0.52.0
 	github.com/aws-controllers-k8s/secretsmanager-controller v0.0.7
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws-controllers-k8s/runtime v0.51.0 h1:ZKu1DXPG7+CsvbEPLMCGqWFdfK37kSbceLzYf9lRZbw=
 github.com/aws-controllers-k8s/runtime v0.51.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
+github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
+github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws-controllers-k8s/secretsmanager-controller v0.0.7 h1:b+RT3ilVlahCSskt91YU784Bj0bF/hff4KaqmVCbisQ=
 github.com/aws-controllers-k8s/secretsmanager-controller v0.0.7/go.mod h1:jVR+yHku29dFDsWDx0NaCfmoSQ0MdT6tiOydxZjAYyc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: kafka-chart
 description: A Helm chart for the ACK service controller for Amazon Managed Streaming for Apache Kafka (MSK)
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1
 home: https://github.com/aws-controllers-k8s/kafka-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/kafka-controller:1.2.0".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/kafka-controller:1.2.1".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "ack-kafka-controller.app.name" . }}
     helm.sh/chart: {{ include "ack-kafka-controller.chart.name-version" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
@@ -88,6 +91,7 @@ spec:
         - --feature-gates
         - "$(FEATURE_GATES)"
 {{- end }}
+        - --enable-carm={{ .Values.enableCARM }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -263,6 +263,11 @@
       },
       "type": "object"
     },
+    "enableCARM": {
+      "description": "Parameter to enable or disable cross account resource management.",
+      "type": "boolean",
+      "default": true
+   },
     "serviceAccount": {
       "description": "ServiceAccount settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/kafka-controller
-  tag: 1.2.0
+  tag: 1.2.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -168,6 +168,9 @@ leaderElection:
   # will attempt to use the namespace of the service account mounted to the Controller
   # pod.
   namespace: ""
+
+# Enable Cross Account Resource Management (default = true). Set this to false to disable cross account resource management.
+enableCARM: true
 
 # Configuration for feature gates.  These are optional controller features that
 # can be individually enabled ("true") or disabled ("false") by adding key/value

--- a/pkg/resource/cluster/resource.go
+++ b/pkg/resource/cluster/resource.go
@@ -97,7 +97,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["arn"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
@@ -105,7 +105,7 @@ func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) erro
 	if r.ko.Status.ACKResourceMetadata == nil {
 		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	arn := ackv1alpha1.AWSResourceName(tmp)
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
 	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil

--- a/pkg/resource/configuration/resource.go
+++ b/pkg/resource/configuration/resource.go
@@ -97,7 +97,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["arn"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
@@ -105,7 +105,7 @@ func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) erro
 	if r.ko.Status.ACKResourceMetadata == nil {
 		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	arn := ackv1alpha1.AWSResourceName(tmp)
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
 	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil

--- a/pkg/resource/serverless_cluster/resource.go
+++ b/pkg/resource/serverless_cluster/resource.go
@@ -97,7 +97,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["arn"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
@@ -105,7 +105,7 @@ func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) erro
 	if r.ko.Status.ACKResourceMetadata == nil {
 		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	arn := ackv1alpha1.AWSResourceName(tmp)
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
 	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil

--- a/test/e2e/resources/cluster_simple.yaml
+++ b/test/e2e/resources/cluster_simple.yaml
@@ -19,7 +19,7 @@ spec:
     storageInfo:
       ebsStorageInfo:
         volumeSize: 10
-  kafkaVersion: "3.3.1"
+  kafkaVersion: "3.9.x"
   # NOTE(jaypipes): Number of broker nodes need to be a multiple of the number
   # of subnets
   numberOfBrokerNodes: 2

--- a/test/e2e/resources/serverlesscluster_simple.yaml
+++ b/test/e2e/resources/serverlesscluster_simple.yaml
@@ -20,5 +20,5 @@ spec:
       storageInfo:
         ebsStorageInfo:
           volumeSize: 10
-    kafkaVersion: "3.3.1"
+    kafkaVersion: "3.9.x"
     numberOfBrokerNodes: 2


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Pin github.com/aws-controllers-k8s/runtime to v0.52.0
- Rebuild with v0.52.0 of code-generator
- Update cluster and serverless cluster e2e tests to use supported Kafka version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
