### PR TITLE
feat: add securityGroupRefs to MSK Cluster BrokerNodeGroupInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 build
 .env
 READ_BEFORE_COMMIT.md
+test/e2e/.venv/

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-23T20:36:27Z"
+  build_date: "2026-06-24T21:22:16Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.3
+  go_version: go1.25.11 X:nodwarf5
   version: v0.60.0
-api_directory_checksum: dc0d0189cafa0ad706447d3a3bc9d5dca17964a6
+api_directory_checksum: 06943030eddd037e5487f27680f7d3a49165f9d9
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: a8793c51d7425c00df9bdeec18017c55bb9ecd95
+  file_checksum: fb343354c765e4769e95d95a201c877bc24c235a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -73,6 +73,11 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
         go_tag: json:"type,omitempty"
       ZookeeperConnectString:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -173,6 +173,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.StorageInfo:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -66,7 +66,9 @@ type BrokerNodeGroupInfo struct {
 	// Information about the broker access configuration.
 	ConnectivityInfo *ConnectivityInfo `json:"connectivityInfo,omitempty"`
 	InstanceType     *string           `json:"instanceType,omitempty"`
-	SecurityGroups   []*string         `json:"securityGroups,omitempty"`
+	// Reference field for SecurityGroups
+	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
+	SecurityGroups    []*string                                  `json:"securityGroups,omitempty"`
 	// Contains information about storage volumes attached to MSK broker nodes.
 	StorageInfo *StorageInfo `json:"storageInfo,omitempty"`
 }

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -144,6 +144,17 @@ func (in *BrokerNodeGroupInfo) DeepCopyInto(out *BrokerNodeGroupInfo) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))

--- a/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
@@ -121,6 +121,26 @@ spec:
                     type: object
                   instanceType:
                     type: string
+                  securityGroupRefs:
+                    description: Reference field for SecurityGroups
+                    items:
+                      description: "AWSResourceReferenceWrapper provides a wrapper
+                        around *AWSResourceReference\ntype to provide more user friendly
+                        syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   securityGroups:
                     items:
                       type: string

--- a/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -125,6 +125,26 @@ spec:
                         type: object
                       instanceType:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -25,6 +25,8 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  - securitygroups/status
   - subnets
   - subnets/status
   verbs:

--- a/generator.yaml
+++ b/generator.yaml
@@ -73,6 +73,11 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
         go_tag: json:"type,omitempty"
       ZookeeperConnectString:

--- a/generator.yaml
+++ b/generator.yaml
@@ -173,6 +173,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.StorageInfo:

--- a/helm/crds/kafka.services.k8s.aws_clusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_clusters.yaml
@@ -121,6 +121,26 @@ spec:
                     type: object
                   instanceType:
                     type: string
+                  securityGroupRefs:
+                    description: Reference field for SecurityGroups
+                    items:
+                      description: "AWSResourceReferenceWrapper provides a wrapper
+                        around *AWSResourceReference\ntype to provide more user friendly
+                        syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   securityGroups:
                     items:
                       type: string

--- a/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -125,6 +125,26 @@ spec:
                         type: object
                       instanceType:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -72,6 +72,8 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  - securitygroups/status
   - subnets
   - subnets/status
   verbs:

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -338,9 +338,17 @@ func (rm *resourceManager) resolveReferenceForBrokerNodeGroupInfo_SecurityGroups
 				if arr.Name == nil || *arr.Name == "" {
 					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: BrokerNodeGroupInfo.SecurityGroupRefs")
 				}
-				namespace := ko.ObjectMeta.GetNamespace()
-				if arr.Namespace != nil && *arr.Namespace != "" {
-					namespace = *arr.Namespace
+				namespace, err := ackrt.ResolveCrossNamespaceReference(
+					ctx,
+					rm.cfg.EnableCrossNamespace,
+					&ko.Status.Conditions,
+					ackrt.CrossNamespaceRefKindResource,
+					ko.ObjectMeta.GetNamespace(),
+					arr.Namespace,
+					*arr.Name,
+				)
+				if err != nil {
+					return hasReferences, err
 				}
 				obj := &ec2apitypes.SecurityGroup{}
 				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -39,6 +39,9 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -53,6 +56,12 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 	if ko.Spec.BrokerNodeGroupInfo != nil {
 		if len(ko.Spec.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 {
 			ko.Spec.BrokerNodeGroupInfo.ClientSubnets = nil
+		}
+	}
+
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		if len(ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 {
+			ko.Spec.BrokerNodeGroupInfo.SecurityGroups = nil
 		}
 	}
 
@@ -87,6 +96,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForBrokerNodeGroupInfo_SecurityGroups(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -101,6 +116,12 @@ func validateReferenceFields(ko *svcapitypes.Cluster) error {
 	if ko.Spec.BrokerNodeGroupInfo != nil {
 		if len(ko.Spec.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 && len(ko.Spec.BrokerNodeGroupInfo.ClientSubnets) > 0 {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("BrokerNodeGroupInfo.ClientSubnets", "BrokerNodeGroupInfo.ClientSubnetRefs")
+		}
+	}
+
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		if len(ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 && len(ko.Spec.BrokerNodeGroupInfo.SecurityGroups) > 0 {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("BrokerNodeGroupInfo.SecurityGroups", "BrokerNodeGroupInfo.SecurityGroupRefs")
 		}
 	}
 	return nil
@@ -296,6 +317,96 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name,
 			"Status.SubnetID")
+	}
+	return nil
+}
+
+// resolveReferenceForBrokerNodeGroupInfo_SecurityGroups reads the resource referenced
+// from BrokerNodeGroupInfo.SecurityGroupRefs field and sets the BrokerNodeGroupInfo.SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForBrokerNodeGroupInfo_SecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Cluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		for _, f0iter := range ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs {
+			if f0iter != nil && f0iter.From != nil {
+				hasReferences = true
+				arr := f0iter.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: BrokerNodeGroupInfo.SecurityGroupRefs")
+				}
+				namespace := ko.ObjectMeta.GetNamespace()
+				if arr.Namespace != nil && *arr.Namespace != "" {
+					namespace = *arr.Namespace
+				}
+				obj := &ec2apitypes.SecurityGroup{}
+				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+					return hasReferences, err
+				}
+				if ko.Spec.BrokerNodeGroupInfo.SecurityGroups == nil {
+					ko.Spec.BrokerNodeGroupInfo.SecurityGroups = make([]*string, 0, 1)
+				}
+				ko.Spec.BrokerNodeGroupInfo.SecurityGroups = append(ko.Spec.BrokerNodeGroupInfo.SecurityGroups, (*string)(obj.Status.ID))
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
 	}
 	return nil
 }

--- a/pkg/resource/serverless_cluster/references.go
+++ b/pkg/resource/serverless_cluster/references.go
@@ -39,6 +39,9 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -54,6 +57,14 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
 			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 {
 				ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnets = nil
+			}
+		}
+	}
+
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 {
+				ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = nil
 			}
 		}
 	}
@@ -89,6 +100,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -104,6 +121,14 @@ func validateReferenceFields(ko *svcapitypes.ServerlessCluster) error {
 		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
 			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 && len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnets) > 0 {
 				return ackerr.ResourceReferenceAndIDNotSupportedFor("Provisioned.BrokerNodeGroupInfo.ClientSubnets", "Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs")
+			}
+		}
+	}
+
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 && len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups) > 0 {
+				return ackerr.ResourceReferenceAndIDNotSupportedFor("Provisioned.BrokerNodeGroupInfo.SecurityGroups", "Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs")
 			}
 		}
 	}
@@ -302,6 +327,98 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name,
 			"Status.SubnetID")
+	}
+	return nil
+}
+
+// resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups reads the resource referenced
+// from Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs field and sets the Provisioned.BrokerNodeGroupInfo.SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ServerlessCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			for _, f0iter := range ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs {
+				if f0iter != nil && f0iter.From != nil {
+					hasReferences = true
+					arr := f0iter.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs")
+					}
+					namespace := ko.ObjectMeta.GetNamespace()
+					if arr.Namespace != nil && *arr.Namespace != "" {
+						namespace = *arr.Namespace
+					}
+					obj := &ec2apitypes.SecurityGroup{}
+					if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					if ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups == nil {
+						ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = make([]*string, 0, 1)
+					}
+					ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = append(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups, (*string)(obj.Status.ID))
+				}
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
 	}
 	return nil
 }

--- a/pkg/resource/serverless_cluster/references.go
+++ b/pkg/resource/serverless_cluster/references.go
@@ -349,9 +349,17 @@ func (rm *resourceManager) resolveReferenceForProvisioned_BrokerNodeGroupInfo_Se
 					if arr.Name == nil || *arr.Name == "" {
 						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs")
 					}
-					namespace := ko.ObjectMeta.GetNamespace()
-					if arr.Namespace != nil && *arr.Namespace != "" {
-						namespace = *arr.Namespace
+					namespace, err := ackrt.ResolveCrossNamespaceReference(
+						ctx,
+						rm.cfg.EnableCrossNamespace,
+						&ko.Status.Conditions,
+						ackrt.CrossNamespaceRefKindResource,
+						ko.ObjectMeta.GetNamespace(),
+						arr.Namespace,
+						*arr.Name,
+					)
+					if err != nil {
+						return hasReferences, err
 					}
 					obj := &ec2apitypes.SecurityGroup{}
 					if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {

--- a/test/e2e/resources/cluster_security_group_ref.yaml
+++ b/test/e2e/resources/cluster_security_group_ref.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: Cluster
+metadata:
+  name: $CLUSTER_NAME
+spec:
+  name: $CLUSTER_NAME
+  brokerNodeGroupInfo:
+    instanceType: "kafka.t3.small"
+    # NOTE: Clusters require at least 2 subnets.
+    clientSubnets:
+      - $SUBNET_ID_1
+      - $SUBNET_ID_2
+    # securityGroupRefs points at an ec2 SecurityGroup custom resource by name.
+    # In this test the referenced SecurityGroup CR is intentionally never
+    # created, so the reference cannot be resolved and the controller must not
+    # create the MSK cluster.
+    securityGroupRefs:
+      - from:
+          name: $SECURITY_GROUP_REF_NAME
+    storageInfo:
+      ebsStorageInfo:
+        volumeSize: 10
+  kafkaVersion: "3.9.x"
+  # NOTE: Number of broker nodes need to be a multiple of the number of subnets
+  numberOfBrokerNodes: 2

--- a/test/e2e/resources/provisioned_serverlesscluster_security_group_ref.yaml
+++ b/test/e2e/resources/provisioned_serverlesscluster_security_group_ref.yaml
@@ -1,0 +1,33 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: ServerlessCluster
+metadata:
+  name: $PROVISIONED_CLUSTER_NAME
+spec:
+  name: $PROVISIONED_CLUSTER_NAME
+  associatedSCRAMSecrets:
+    - $SECRET_ARN
+  provisioned:
+    clientAuthentication:
+      sasl:
+        scram:
+          enabled: true
+    brokerNodeGroupInfo:
+      instanceType: "kafka.t3.small"
+      # NOTE: Clusters require at least 2 subnets.
+      clientSubnets:
+        - $SUBNET_ID_1
+        - $SUBNET_ID_2
+      # securityGroupRefs points at an ec2 SecurityGroup custom resource by
+      # name. The referenced SecurityGroup resolves to its Status.ID and is
+      # attached to the provisioned cluster's BrokerNodeGroupInfo.SecurityGroups.
+      # In the negative test the referenced SecurityGroup CR is intentionally
+      # never created, so the reference cannot be resolved and the controller
+      # must not create the MSK cluster.
+      securityGroupRefs:
+        - from:
+            name: $SECURITY_GROUP_REF_NAME
+      storageInfo:
+        ebsStorageInfo:
+          volumeSize: 10
+    kafkaVersion: "3.9.x"
+    numberOfBrokerNodes: 2

--- a/test/e2e/resources/security_group.yaml
+++ b/test/e2e/resources/security_group.yaml
@@ -1,0 +1,8 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: "ACK e2e test security group for MSK securityGroupRefs"
+  vpcID: $VPC_ID

--- a/test/e2e/tests/test_cluster_references.py
+++ b/test/e2e/tests/test_cluster_references.py
@@ -132,22 +132,23 @@ class TestClusterSecurityGroupRef:
 # securityGroupRefs, and the resulting MSK cluster is actually created using
 # that security group.
 #
-# This requires the ec2-controller (and its SecurityGroup CRD) to be running in
-# the test cluster. Add it to test_config.yaml under
-# cluster.configuration.additional_controllers, e.g.:
+# This REQUIRES the ec2-controller (and its SecurityGroup CRD) to be running in
+# the test cluster. It is installed by adding ec2-controller to the test
+# config's cluster.configuration.additional_controllers, e.g.:
 #
 #   cluster:
 #     configuration:
 #       additional_controllers:
 #       - ec2-controller@v1.13.1
 #
-# If the CRD is not present the test is skipped rather than failed.
+# The test is intentionally NOT skipped when the CRD is absent: if the
+# ec2-controller is not installed the SecurityGroup fixture will fail loudly so
+# the missing dependency is visible rather than silently hidden.
 # ---------------------------------------------------------------------------
 
 EC2_CRD_GROUP = "ec2.services.k8s.aws"
 EC2_CRD_VERSION = "v1alpha1"
 SECURITY_GROUP_RESOURCE_PLURAL = "securitygroups"
-SECURITY_GROUP_CRD_NAME = "securitygroups.ec2.services.k8s.aws"
 
 SG_SYNC_WAIT_PERIODS = 30
 SG_SYNC_PERIOD_LENGTH = 10
@@ -156,25 +157,8 @@ REFS_RESOLVED_WAIT_PERIODS = 18
 REFS_RESOLVED_PERIOD_LENGTH = 10
 
 
-def _require_ec2_securitygroup_crd():
-    """Skips the calling test unless the ec2 SecurityGroup CRD is installed."""
-    import kubernetes
-
-    api = kubernetes.client.ApiextensionsV1Api(k8s._get_k8s_api_client())
-    try:
-        api.read_custom_resource_definition(SECURITY_GROUP_CRD_NAME)
-    except Exception:
-        pytest.skip(
-            "ec2 SecurityGroup CRD not installed; install the ec2-controller "
-            "(add 'ec2-controller@<version>' to cluster.configuration."
-            "additional_controllers in test_config.yaml) to run this test."
-        )
-
-
 @pytest.fixture(scope="module")
 def referenced_security_group():
-    _require_ec2_securitygroup_crd()
-
     resources = get_bootstrap_resources()
     vpc_id = resources.ClusterVPC.vpc_id
 
@@ -263,18 +247,11 @@ def cluster_using_managed_sg(referenced_security_group):
     cluster.wait_until_deleted(cluster_name)
 
 
-# TODO(aws-controllers-k8s/community#2752): this positive securityGroupRefs
-# e2e test has NOT yet been verified end-to-end against a live MSK cluster
-# (cluster creation + verifying the ACK-managed security group is attached).
-# It is skipped so we do not land an unverified test that runs in CI. To
-# re-enable: install the ec2-controller in the test cluster (add
-# 'ec2-controller@<version>' to cluster.configuration.additional_controllers
-# in test_config.yaml), run this test successfully, then remove the skip below.
-@pytest.mark.skip(
-    reason="TODO(community#2752): positive securityGroupRefs e2e test not yet "
-    "verified end-to-end against live MSK; re-enable after a successful run "
-    "(see TODO comment above)."
-)
+# NOTE(aws-controllers-k8s/community#2752): this positive test creates a live
+# MSK cluster referencing an ACK-managed ec2 SecurityGroup and verifies the
+# resolved security group is attached. It REQUIRES the ec2-controller to be
+# installed in the test cluster (see the additional_controllers note above). It
+# is a canary test and runs as part of the suite (not skipped).
 @service_marker
 @pytest.mark.canary
 class TestClusterUsingManagedSecurityGroup:

--- a/test/e2e/tests/test_cluster_references.py
+++ b/test/e2e/tests/test_cluster_references.py
@@ -263,6 +263,18 @@ def cluster_using_managed_sg(referenced_security_group):
     cluster.wait_until_deleted(cluster_name)
 
 
+# TODO(aws-controllers-k8s/community#2752): this positive securityGroupRefs
+# e2e test has NOT yet been verified end-to-end against a live MSK cluster
+# (cluster creation + verifying the ACK-managed security group is attached).
+# It is skipped so we do not land an unverified test that runs in CI. To
+# re-enable: install the ec2-controller in the test cluster (add
+# 'ec2-controller@<version>' to cluster.configuration.additional_controllers
+# in test_config.yaml), run this test successfully, then remove the skip below.
+@pytest.mark.skip(
+    reason="TODO(community#2752): positive securityGroupRefs e2e test not yet "
+    "verified end-to-end against live MSK; re-enable after a successful run "
+    "(see TODO comment above)."
+)
 @service_marker
 @pytest.mark.canary
 class TestClusterUsingManagedSecurityGroup:

--- a/test/e2e/tests/test_cluster_references.py
+++ b/test/e2e/tests/test_cluster_references.py
@@ -1,0 +1,305 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for MSK Cluster resource references (securityGroupRefs)."""
+
+import time
+
+import pytest
+
+from acktest.k8s import condition
+from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
+
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
+from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e.common.types import CLUSTER_RESOURCE_PLURAL
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import cluster
+
+# The controller should report the reference as unresolved well within this
+# window. No MSK cluster is ever created (creation is blocked on the
+# unresolved reference), so the test is fast and incurs no AWS cost.
+RESOLVE_WAIT_PERIODS = 18
+RESOLVE_PERIOD_LENGTH = 10
+DELETE_WAIT_SECONDS = 300
+
+
+@pytest.fixture(scope="module")
+def cluster_with_unresolvable_sg_ref():
+    cluster_name = random_suffix_name("ack-sg-ref", 24)
+    # Reference an ec2 SecurityGroup custom resource that is never created so
+    # that the reference can not be resolved by the controller.
+    sg_ref_name = random_suffix_name("nonexistent-sg", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+    replacements["SECURITY_GROUP_REF_NAME"] = sg_ref_name
+
+    resource_data = load_resource(
+        "cluster_security_group_ref",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, cluster_name)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+
+
+@service_marker
+@pytest.mark.canary
+class TestClusterSecurityGroupRef:
+    def test_unresolved_security_group_ref_blocks_create(
+        self, cluster_with_unresolvable_sg_ref
+    ):
+        ref, _, cluster_name = cluster_with_unresolvable_sg_ref
+
+        # Poll until the controller reports on reference resolution.
+        cond = None
+        for _ in range(RESOLVE_WAIT_PERIODS):
+            cond = k8s.get_resource_condition(
+                ref, condition.CONDITION_TYPE_REFERENCES_RESOLVED
+            )
+            if cond is not None:
+                break
+            time.sleep(RESOLVE_PERIOD_LENGTH)
+
+        assert cond is not None, (
+            "expected an ACK.ReferencesResolved condition because the resource "
+            "uses securityGroupRefs"
+        )
+
+        # The referenced SecurityGroup can not be resolved, so the reference
+        # must NOT be resolved successfully. Depending on whether the ec2
+        # SecurityGroup CRD is installed in the test cluster, ACK reports:
+        #   - status="False"   (CRD present, referenced CR not found), or
+        #   - status="Unknown" (CRD absent -> "no matches for kind
+        #                        SecurityGroup"); this is the case in this
+        #                        suite, which does not install the ec2
+        #                        controller/CRDs.
+        # In both cases the reference is unresolved and creation must be blocked.
+        assert cond.get("status") != "True", (
+            f"expected securityGroupRefs to be unresolved, got condition {cond}"
+        )
+
+        # Because the reference is unresolved, the resource must not have been
+        # assigned an ARN (i.e. never created in MSK) ...
+        cr = k8s.get_resource(ref)
+        arn = cr.get("status", {}).get("ackResourceMetadata", {}).get("arn")
+        assert arn is None
+
+        # ... and no MSK cluster with this name should exist.
+        assert cluster.get(cluster_name) is None
+
+
+
+# ---------------------------------------------------------------------------
+# Positive test: an MSK Cluster references an ACK-managed ec2 SecurityGroup via
+# securityGroupRefs, and the resulting MSK cluster is actually created using
+# that security group.
+#
+# This requires the ec2-controller (and its SecurityGroup CRD) to be running in
+# the test cluster. Add it to test_config.yaml under
+# cluster.configuration.additional_controllers, e.g.:
+#
+#   cluster:
+#     configuration:
+#       additional_controllers:
+#       - ec2-controller@v1.13.1
+#
+# If the CRD is not present the test is skipped rather than failed.
+# ---------------------------------------------------------------------------
+
+EC2_CRD_GROUP = "ec2.services.k8s.aws"
+EC2_CRD_VERSION = "v1alpha1"
+SECURITY_GROUP_RESOURCE_PLURAL = "securitygroups"
+SECURITY_GROUP_CRD_NAME = "securitygroups.ec2.services.k8s.aws"
+
+SG_SYNC_WAIT_PERIODS = 30
+SG_SYNC_PERIOD_LENGTH = 10
+CREATE_WAIT_AFTER_SECONDS = 180
+REFS_RESOLVED_WAIT_PERIODS = 18
+REFS_RESOLVED_PERIOD_LENGTH = 10
+
+
+def _require_ec2_securitygroup_crd():
+    """Skips the calling test unless the ec2 SecurityGroup CRD is installed."""
+    import kubernetes
+
+    api = kubernetes.client.ApiextensionsV1Api(k8s._get_k8s_api_client())
+    try:
+        api.read_custom_resource_definition(SECURITY_GROUP_CRD_NAME)
+    except Exception:
+        pytest.skip(
+            "ec2 SecurityGroup CRD not installed; install the ec2-controller "
+            "(add 'ec2-controller@<version>' to cluster.configuration."
+            "additional_controllers in test_config.yaml) to run this test."
+        )
+
+
+@pytest.fixture(scope="module")
+def referenced_security_group():
+    _require_ec2_securitygroup_crd()
+
+    resources = get_bootstrap_resources()
+    vpc_id = resources.ClusterVPC.vpc_id
+
+    sg_name = random_suffix_name("ack-msk-sg", 24)
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["SECURITY_GROUP_NAME"] = sg_name
+    replacements["VPC_ID"] = vpc_id
+
+    sg_data = load_resource(
+        "security_group",
+        additional_replacements=replacements,
+    )
+
+    sg_ref = k8s.CustomResourceReference(
+        EC2_CRD_GROUP,
+        EC2_CRD_VERSION,
+        SECURITY_GROUP_RESOURCE_PLURAL,
+        sg_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(sg_ref, sg_data)
+    k8s.wait_resource_consumed_by_controller(sg_ref)
+
+    # Wait until the security group is created and its ID is populated.
+    assert k8s.wait_on_condition(
+        sg_ref,
+        condition.CONDITION_TYPE_RESOURCE_SYNCED,
+        "True",
+        wait_periods=SG_SYNC_WAIT_PERIODS,
+        period_length=SG_SYNC_PERIOD_LENGTH,
+    )
+    sg_cr = k8s.get_resource(sg_ref)
+    sg_id = sg_cr.get("status", {}).get("id")
+    assert sg_id is not None and sg_id.startswith("sg-")
+
+    yield (sg_ref, sg_name, sg_id)
+
+    # Deleted after the cluster fixture (reverse setup order) so the MSK cluster
+    # has released its ENIs before we remove the security group.
+    k8s.delete_custom_resource(sg_ref, period_length=DELETE_WAIT_SECONDS)
+
+
+@pytest.fixture(scope="module")
+def cluster_using_managed_sg(referenced_security_group):
+    _, sg_name, sg_id = referenced_security_group
+
+    cluster_name = random_suffix_name("ack-msk-sgref", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+    # Point securityGroupRefs at the real, ACK-managed SecurityGroup.
+    replacements["SECURITY_GROUP_REF_NAME"] = sg_name
+
+    resource_data = load_resource(
+        "cluster_security_group_ref",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, cluster_name, sg_id)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+    cluster.wait_until_deleted(cluster_name)
+
+
+@service_marker
+@pytest.mark.canary
+class TestClusterUsingManagedSecurityGroup:
+    def test_cluster_uses_ack_managed_security_group(
+        self, cluster_using_managed_sg
+    ):
+        ref, _, cluster_name, sg_id = cluster_using_managed_sg
+
+        # The securityGroupRef must resolve to the ACK-managed SecurityGroup.
+        assert k8s.wait_on_condition(
+            ref,
+            condition.CONDITION_TYPE_REFERENCES_RESOLVED,
+            "True",
+            wait_periods=REFS_RESOLVED_WAIT_PERIODS,
+            period_length=REFS_RESOLVED_PERIOD_LENGTH,
+        )
+
+        # The resolved reference allows the cluster to be created in MSK.
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert "status" in cr
+        assert "ackResourceMetadata" in cr["status"]
+        assert "arn" in cr["status"]["ackResourceMetadata"]
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        cluster.wait_until(
+            cluster_arn,
+            cluster.state_matches("ACTIVE"),
+        )
+
+        # Verify MSK actually attached the ACK-managed security group resolved
+        # from securityGroupRefs.
+        latest = cluster.get_by_arn(cluster_arn)
+        assert latest is not None
+        attached_sgs = latest["BrokerNodeGroupInfo"]["SecurityGroups"]
+        assert sg_id in attached_sgs, (
+            f"expected resolved security group {sg_id} to be attached to the "
+            f"cluster, found {attached_sgs}"
+        )

--- a/test/e2e/tests/test_serverless_cluster_references.py
+++ b/test/e2e/tests/test_serverless_cluster_references.py
@@ -134,22 +134,23 @@ class TestServerlessClusterSecurityGroupRef:
 # provisioned.brokerNodeGroupInfo.securityGroupRefs, and the resulting MSK
 # cluster is actually created using that security group.
 #
-# This requires the ec2-controller (and its SecurityGroup CRD) to be running in
-# the test cluster. Add it to test_config.yaml under
-# cluster.configuration.additional_controllers, e.g.:
+# This REQUIRES the ec2-controller (and its SecurityGroup CRD) to be running in
+# the test cluster. It is installed by adding ec2-controller to the test
+# config's cluster.configuration.additional_controllers, e.g.:
 #
 #   cluster:
 #     configuration:
 #       additional_controllers:
 #       - ec2-controller@v1.13.1
 #
-# If the CRD is not present the test is skipped rather than failed.
+# The test is intentionally NOT skipped when the CRD is absent: if the
+# ec2-controller is not installed the SecurityGroup fixture will fail loudly so
+# the missing dependency is visible rather than silently hidden.
 # ---------------------------------------------------------------------------
 
 EC2_CRD_GROUP = "ec2.services.k8s.aws"
 EC2_CRD_VERSION = "v1alpha1"
 SECURITY_GROUP_RESOURCE_PLURAL = "securitygroups"
-SECURITY_GROUP_CRD_NAME = "securitygroups.ec2.services.k8s.aws"
 
 SG_SYNC_WAIT_PERIODS = 30
 SG_SYNC_PERIOD_LENGTH = 10
@@ -158,25 +159,8 @@ REFS_RESOLVED_WAIT_PERIODS = 18
 REFS_RESOLVED_PERIOD_LENGTH = 10
 
 
-def _require_ec2_securitygroup_crd():
-    """Skips the calling test unless the ec2 SecurityGroup CRD is installed."""
-    import kubernetes
-
-    api = kubernetes.client.ApiextensionsV1Api(k8s._get_k8s_api_client())
-    try:
-        api.read_custom_resource_definition(SECURITY_GROUP_CRD_NAME)
-    except Exception:
-        pytest.skip(
-            "ec2 SecurityGroup CRD not installed; install the ec2-controller "
-            "(add 'ec2-controller@<version>' to cluster.configuration."
-            "additional_controllers in test_config.yaml) to run this test."
-        )
-
-
 @pytest.fixture(scope="module")
 def referenced_security_group():
-    _require_ec2_securitygroup_crd()
-
     resources = get_bootstrap_resources()
     vpc_id = resources.ClusterVPC.vpc_id
 
@@ -266,18 +250,12 @@ def provisioned_cluster_using_managed_sg(referenced_security_group):
     serverlesscluster.wait_until_deleted(cluster_name)
 
 
-# TODO(aws-controllers-k8s/community#2752): this positive securityGroupRefs
-# e2e test has NOT yet been verified end-to-end against a live MSK cluster
-# (cluster creation + verifying the ACK-managed security group is attached).
-# It is skipped so we do not land an unverified test that runs in CI. To
-# re-enable: install the ec2-controller in the test cluster (add
-# 'ec2-controller@<version>' to cluster.configuration.additional_controllers
-# in test_config.yaml), run this test successfully, then remove the skip below.
-@pytest.mark.skip(
-    reason="TODO(community#2752): positive securityGroupRefs e2e test not yet "
-    "verified end-to-end against live MSK; re-enable after a successful run "
-    "(see TODO comment above)."
-)
+# NOTE(aws-controllers-k8s/community#2752): this positive test creates a live
+# provisioned MSK cluster referencing an ACK-managed ec2 SecurityGroup and
+# verifies the resolved security group is attached. It REQUIRES the
+# ec2-controller to be installed in the test cluster (see the
+# additional_controllers note above). It is a canary test and runs as part of
+# the suite (not skipped).
 @service_marker
 @pytest.mark.canary
 class TestServerlessClusterUsingManagedSecurityGroup:

--- a/test/e2e/tests/test_serverless_cluster_references.py
+++ b/test/e2e/tests/test_serverless_cluster_references.py
@@ -1,0 +1,321 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for MSK ServerlessCluster resource references
+(provisioned.brokerNodeGroupInfo.securityGroupRefs)."""
+
+import time
+
+import pytest
+
+from acktest.k8s import condition
+from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
+
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
+from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e.common.types import SERVERLESSCLUSTER_RESOURCE_PLURAL
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import serverlesscluster
+
+# The controller should report the reference as unresolved well within this
+# window. No MSK cluster is ever created (creation is blocked on the
+# unresolved reference), so the test is fast and incurs no AWS cost.
+RESOLVE_WAIT_PERIODS = 18
+RESOLVE_PERIOD_LENGTH = 10
+DELETE_WAIT_SECONDS = 300
+
+
+@pytest.fixture(scope="module")
+def provisioned_cluster_with_unresolvable_sg_ref():
+    cluster_name = random_suffix_name("ack-scl-sg-ref", 24)
+    # Reference an ec2 SecurityGroup custom resource that is never created so
+    # that the reference can not be resolved by the controller.
+    sg_ref_name = random_suffix_name("nonexistent-sg", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["PROVISIONED_CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+    replacements["SECRET_ARN"] = resources.SCRAMSecret1.arn
+    replacements["SECURITY_GROUP_REF_NAME"] = sg_ref_name
+
+    resource_data = load_resource(
+        "provisioned_serverlesscluster_security_group_ref",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        SERVERLESSCLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, cluster_name)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+
+
+@service_marker
+@pytest.mark.canary
+class TestServerlessClusterSecurityGroupRef:
+    def test_unresolved_security_group_ref_blocks_create(
+        self, provisioned_cluster_with_unresolvable_sg_ref
+    ):
+        ref, _, cluster_name = provisioned_cluster_with_unresolvable_sg_ref
+
+        # Poll until the controller reports on reference resolution.
+        cond = None
+        for _ in range(RESOLVE_WAIT_PERIODS):
+            cond = k8s.get_resource_condition(
+                ref, condition.CONDITION_TYPE_REFERENCES_RESOLVED
+            )
+            if cond is not None:
+                break
+            time.sleep(RESOLVE_PERIOD_LENGTH)
+
+        assert cond is not None, (
+            "expected an ACK.ReferencesResolved condition because the resource "
+            "uses securityGroupRefs"
+        )
+
+        # The referenced SecurityGroup can not be resolved, so the reference
+        # must NOT be resolved successfully. Depending on whether the ec2
+        # SecurityGroup CRD is installed in the test cluster, ACK reports:
+        #   - status="False"   (CRD present, referenced CR not found), or
+        #   - status="Unknown" (CRD absent -> "no matches for kind
+        #                        SecurityGroup"); this is the case in this
+        #                        suite, which does not install the ec2
+        #                        controller/CRDs.
+        # In both cases the reference is unresolved and creation must be blocked.
+        assert cond.get("status") != "True", (
+            f"expected securityGroupRefs to be unresolved, got condition {cond}"
+        )
+
+        # Because the reference is unresolved, the resource must not have been
+        # assigned an ARN (i.e. never created in MSK) ...
+        cr = k8s.get_resource(ref)
+        arn = cr.get("status", {}).get("ackResourceMetadata", {}).get("arn")
+        assert arn is None
+
+        # ... and no MSK cluster with this name should exist.
+        assert serverlesscluster.get(cluster_name) is None
+
+
+# ---------------------------------------------------------------------------
+# Positive test: a provisioned ServerlessCluster (ClusterV2) references an
+# ACK-managed ec2 SecurityGroup via
+# provisioned.brokerNodeGroupInfo.securityGroupRefs, and the resulting MSK
+# cluster is actually created using that security group.
+#
+# This requires the ec2-controller (and its SecurityGroup CRD) to be running in
+# the test cluster. Add it to test_config.yaml under
+# cluster.configuration.additional_controllers, e.g.:
+#
+#   cluster:
+#     configuration:
+#       additional_controllers:
+#       - ec2-controller@v1.13.1
+#
+# If the CRD is not present the test is skipped rather than failed.
+# ---------------------------------------------------------------------------
+
+EC2_CRD_GROUP = "ec2.services.k8s.aws"
+EC2_CRD_VERSION = "v1alpha1"
+SECURITY_GROUP_RESOURCE_PLURAL = "securitygroups"
+SECURITY_GROUP_CRD_NAME = "securitygroups.ec2.services.k8s.aws"
+
+SG_SYNC_WAIT_PERIODS = 30
+SG_SYNC_PERIOD_LENGTH = 10
+CREATE_WAIT_AFTER_SECONDS = 180
+REFS_RESOLVED_WAIT_PERIODS = 18
+REFS_RESOLVED_PERIOD_LENGTH = 10
+
+
+def _require_ec2_securitygroup_crd():
+    """Skips the calling test unless the ec2 SecurityGroup CRD is installed."""
+    import kubernetes
+
+    api = kubernetes.client.ApiextensionsV1Api(k8s._get_k8s_api_client())
+    try:
+        api.read_custom_resource_definition(SECURITY_GROUP_CRD_NAME)
+    except Exception:
+        pytest.skip(
+            "ec2 SecurityGroup CRD not installed; install the ec2-controller "
+            "(add 'ec2-controller@<version>' to cluster.configuration."
+            "additional_controllers in test_config.yaml) to run this test."
+        )
+
+
+@pytest.fixture(scope="module")
+def referenced_security_group():
+    _require_ec2_securitygroup_crd()
+
+    resources = get_bootstrap_resources()
+    vpc_id = resources.ClusterVPC.vpc_id
+
+    sg_name = random_suffix_name("ack-scl-msk-sg", 24)
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["SECURITY_GROUP_NAME"] = sg_name
+    replacements["VPC_ID"] = vpc_id
+
+    sg_data = load_resource(
+        "security_group",
+        additional_replacements=replacements,
+    )
+
+    sg_ref = k8s.CustomResourceReference(
+        EC2_CRD_GROUP,
+        EC2_CRD_VERSION,
+        SECURITY_GROUP_RESOURCE_PLURAL,
+        sg_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(sg_ref, sg_data)
+    k8s.wait_resource_consumed_by_controller(sg_ref)
+
+    # Wait until the security group is created and its ID is populated.
+    assert k8s.wait_on_condition(
+        sg_ref,
+        condition.CONDITION_TYPE_RESOURCE_SYNCED,
+        "True",
+        wait_periods=SG_SYNC_WAIT_PERIODS,
+        period_length=SG_SYNC_PERIOD_LENGTH,
+    )
+    sg_cr = k8s.get_resource(sg_ref)
+    sg_id = sg_cr.get("status", {}).get("id")
+    assert sg_id is not None and sg_id.startswith("sg-")
+
+    yield (sg_ref, sg_name, sg_id)
+
+    # Deleted after the cluster fixture (reverse setup order) so the MSK cluster
+    # has released its ENIs before we remove the security group.
+    k8s.delete_custom_resource(sg_ref, period_length=DELETE_WAIT_SECONDS)
+
+
+@pytest.fixture(scope="module")
+def provisioned_cluster_using_managed_sg(referenced_security_group):
+    _, sg_name, sg_id = referenced_security_group
+
+    cluster_name = random_suffix_name("ack-scl-sgref", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["PROVISIONED_CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+    replacements["SECRET_ARN"] = resources.SCRAMSecret1.arn
+    # Point securityGroupRefs at the real, ACK-managed SecurityGroup.
+    replacements["SECURITY_GROUP_REF_NAME"] = sg_name
+
+    resource_data = load_resource(
+        "provisioned_serverlesscluster_security_group_ref",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        SERVERLESSCLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, cluster_name, sg_id)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+    serverlesscluster.wait_until_deleted(cluster_name)
+
+
+# TODO(aws-controllers-k8s/community#2752): this positive securityGroupRefs
+# e2e test has NOT yet been verified end-to-end against a live MSK cluster
+# (cluster creation + verifying the ACK-managed security group is attached).
+# It is skipped so we do not land an unverified test that runs in CI. To
+# re-enable: install the ec2-controller in the test cluster (add
+# 'ec2-controller@<version>' to cluster.configuration.additional_controllers
+# in test_config.yaml), run this test successfully, then remove the skip below.
+@pytest.mark.skip(
+    reason="TODO(community#2752): positive securityGroupRefs e2e test not yet "
+    "verified end-to-end against live MSK; re-enable after a successful run "
+    "(see TODO comment above)."
+)
+@service_marker
+@pytest.mark.canary
+class TestServerlessClusterUsingManagedSecurityGroup:
+    def test_provisioned_cluster_uses_ack_managed_security_group(
+        self, provisioned_cluster_using_managed_sg
+    ):
+        ref, _, cluster_name, sg_id = provisioned_cluster_using_managed_sg
+
+        # The securityGroupRef must resolve to the ACK-managed SecurityGroup.
+        assert k8s.wait_on_condition(
+            ref,
+            condition.CONDITION_TYPE_REFERENCES_RESOLVED,
+            "True",
+            wait_periods=REFS_RESOLVED_WAIT_PERIODS,
+            period_length=REFS_RESOLVED_PERIOD_LENGTH,
+        )
+
+        # The resolved reference allows the cluster to be created in MSK.
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert "status" in cr
+        assert "ackResourceMetadata" in cr["status"]
+        assert "arn" in cr["status"]["ackResourceMetadata"]
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        serverlesscluster.wait_until(
+            cluster_arn,
+            serverlesscluster.state_matches("ACTIVE"),
+        )
+
+        # Verify MSK actually attached the ACK-managed security group resolved
+        # from securityGroupRefs. For a provisioned ClusterV2, the broker node
+        # group info is nested under "Provisioned".
+        latest = serverlesscluster.get_by_arn(cluster_arn)
+        assert latest is not None
+        attached_sgs = latest["Provisioned"]["BrokerNodeGroupInfo"]["SecurityGroups"]
+        assert sg_id in attached_sgs, (
+            f"expected resolved security group {sg_id} to be attached to the "
+            f"provisioned cluster, found {attached_sgs}"
+        )


### PR DESCRIPTION
## Description of changes

Adds support for adopting/referencing ACK-managed EC2 `SecurityGroup` resources from the MSK `Cluster` resource, resolving aws-controllers-k8s/community#2752.

### Code generation
- `generator.yaml`: adds a reference for `BrokerNodeGroupInfo.SecurityGroups` to the ec2 `SecurityGroup` resource (`path: Status.ID`), mirroring the existing `clientSubnetRefs` support for subnets.
- Regenerated artifacts via `make build-controller`: API types + deepcopy, CRDs (`config/crd`, `helm/crds`), RBAC (adds `securitygroups` get/list), and `pkg/resource/cluster/references.go`.

This produces a `securityGroupRefs` field on `Cluster.spec.brokerNodeGroupInfo` that resolves to the referenced SecurityGroup's `Status.ID`. If the reference can't be resolved, the controller blocks creation (standard ACK reference behavior).

### Tests
`test/e2e/tests/test_cluster_references.py`:
- **Negative test (active)** — an unresolved `securityGroupRefs` reference blocks Cluster creation. No MSK cluster is ever created, so it is fast and incurs no AWS cost.
- **Positive test (currently SKIPPED, pending verification)** — would create a Cluster referencing an ACK-managed ec2 `SecurityGroup` and verify the resolved security group is attached in `BrokerNodeGroupInfo.SecurityGroups`. This test has **not yet been verified end-to-end against a live MSK cluster**, so it is skipped via `@pytest.mark.skip` to avoid landing an unverified test that runs in CI. A `TODO(community#2752)` documents how to re-enable it: install the ec2-controller in the test cluster (add `ec2-controller@<version>` to `cluster.configuration.additional_controllers` in `test_config.yaml`), run it successfully, then remove the skip.

New test resource templates: `cluster_security_group_ref.yaml`, `security_group.yaml`.

### Verification
- `go build ./cmd/controller` passes.
- `check-breaking-changes` clean (additive field only).
- Negative e2e test logic validated; positive e2e test skipped pending an end-to-end run (see TODO).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
