### PR TITLE
fix: externally managed scram secrets should not be disassociated by …

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-06-05T18:07:23Z"
-  build_hash: 8d8f5f2406b145d2bf19f9bba75086b2445ffe4b
+  build_date: "2026-06-17T17:29:17Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
   go_version: go1.26.3
-  version: v0.59.1-6-g8d8f5f2
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: 9cd123417f2c6aa972c9541b6755ed3305c076ea
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -577,6 +577,15 @@ func (rm *resourceManager) syncAssociatedScramSecrets(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.syncAssociatedScramSecrets")
 	defer func() { exit(err) }()
+
+	// When the spec omits AssociatedSCRAMSecrets (nil), treat the field as
+	// unmanaged so secrets associated out-of-band are not disassociated.
+	// A empty list can specified in the CR, means the user wants no associated
+	// secrets and any existing associations should be removed.
+	if desired.ko.Spec.AssociatedSCRAMSecrets == nil {
+		return nil
+	}
+
 	toAdd := []*string{}
 	toDelete := []*string{}
 
@@ -789,6 +798,12 @@ func (rm *resourceManager) setBootstrapBrokerStringInformations(ctx context.Cont
 }
 
 func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
+	// When the spec omits AssociatedSCRAMSecrets, treat the field as
+	// unmanaged: copy observed onto desired so the delta sees them as equal
+	// and externally associated secrets are never disassociated.
+	if a.ko.Spec.AssociatedSCRAMSecrets == nil {
+		a.ko.Spec.AssociatedSCRAMSecrets = b.ko.Spec.AssociatedSCRAMSecrets
+	}
 	// Set MSK defaults
 	if a.ko.Spec.BrokerNodeGroupInfo == nil {
 		a.ko.Spec.BrokerNodeGroupInfo = b.ko.Spec.BrokerNodeGroupInfo


### PR DESCRIPTION
…the controller

Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2919

Description of changes: This PR attempts to fix the issue with the controller disassociating externally managed MSK secrets that are not managed via the Cluster CR. 

> Note: this doesn't currently handle the mix case where secrets can be managed by the controller and externally. The fix in this pr only applies to the use case when the AssociatedSCRAMSecrets is completely empty (nil) in the cr spec

Also: this was a similar issue with Terraform which was solved with a separate resource: https://github.com/hashicorp/terraform-provider-aws/issues/16791

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
