### PR TITLE
Add ec2 SecurityGroup references to Cluster and ServerlessCluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-23T20:36:27Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.3
-  version: v0.60.0
-api_directory_checksum: dc0d0189cafa0ad706447d3a3bc9d5dca17964a6
+  build_date: "2026-06-25T19:34:35Z"
+  build_hash: 016cc97b328515c8db205ad1091916a0cc66614b
+  go_version: go1.26.0
+  version: v0.60.0-2-g016cc97
+api_directory_checksum: f316b4b83619b4f6e718dd5ead8e3edd1a3d21f6
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: a8793c51d7425c00df9bdeec18017c55bb9ecd95
+  file_checksum: fb343354c765e4769e95d95a201c877bc24c235a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -73,6 +73,11 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
         go_tag: json:"type,omitempty"
       ZookeeperConnectString:
@@ -168,6 +173,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.StorageInfo:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -66,7 +66,9 @@ type BrokerNodeGroupInfo struct {
 	// Information about the broker access configuration.
 	ConnectivityInfo *ConnectivityInfo `json:"connectivityInfo,omitempty"`
 	InstanceType     *string           `json:"instanceType,omitempty"`
-	SecurityGroups   []*string         `json:"securityGroups,omitempty"`
+	// Reference field for SecurityGroups
+	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
+	SecurityGroups    []*string                                  `json:"securityGroups,omitempty"`
 	// Contains information about storage volumes attached to MSK broker nodes.
 	StorageInfo *StorageInfo `json:"storageInfo,omitempty"`
 }

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -144,6 +144,17 @@ func (in *BrokerNodeGroupInfo) DeepCopyInto(out *BrokerNodeGroupInfo) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))

--- a/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
@@ -121,6 +121,26 @@ spec:
                     type: object
                   instanceType:
                     type: string
+                  securityGroupRefs:
+                    description: Reference field for SecurityGroups
+                    items:
+                      description: "AWSResourceReferenceWrapper provides a wrapper
+                        around *AWSResourceReference\ntype to provide more user friendly
+                        syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   securityGroups:
                     items:
                       type: string

--- a/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -125,6 +125,26 @@ spec:
                         type: object
                       instanceType:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -25,6 +25,8 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  - securitygroups/status
   - subnets
   - subnets/status
   verbs:

--- a/generator.yaml
+++ b/generator.yaml
@@ -73,6 +73,11 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type:
         go_tag: json:"type,omitempty"
       ZookeeperConnectString:
@@ -168,6 +173,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.SecurityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
         late_initialize:
           skip_incomplete_check: {}
       Provisioned.BrokerNodeGroupInfo.StorageInfo:

--- a/helm/crds/kafka.services.k8s.aws_clusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_clusters.yaml
@@ -121,6 +121,26 @@ spec:
                     type: object
                   instanceType:
                     type: string
+                  securityGroupRefs:
+                    description: Reference field for SecurityGroups
+                    items:
+                      description: "AWSResourceReferenceWrapper provides a wrapper
+                        around *AWSResourceReference\ntype to provide more user friendly
+                        syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   securityGroups:
                     items:
                       type: string

--- a/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -125,6 +125,26 @@ spec:
                         type: object
                       instanceType:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -72,6 +72,8 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  - securitygroups/status
   - subnets
   - subnets/status
   verbs:

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -39,6 +39,9 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -53,6 +56,12 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 	if ko.Spec.BrokerNodeGroupInfo != nil {
 		if len(ko.Spec.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 {
 			ko.Spec.BrokerNodeGroupInfo.ClientSubnets = nil
+		}
+	}
+
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		if len(ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 {
+			ko.Spec.BrokerNodeGroupInfo.SecurityGroups = nil
 		}
 	}
 
@@ -87,6 +96,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForBrokerNodeGroupInfo_SecurityGroups(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -101,6 +116,12 @@ func validateReferenceFields(ko *svcapitypes.Cluster) error {
 	if ko.Spec.BrokerNodeGroupInfo != nil {
 		if len(ko.Spec.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 && len(ko.Spec.BrokerNodeGroupInfo.ClientSubnets) > 0 {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("BrokerNodeGroupInfo.ClientSubnets", "BrokerNodeGroupInfo.ClientSubnetRefs")
+		}
+	}
+
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		if len(ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 && len(ko.Spec.BrokerNodeGroupInfo.SecurityGroups) > 0 {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("BrokerNodeGroupInfo.SecurityGroups", "BrokerNodeGroupInfo.SecurityGroupRefs")
 		}
 	}
 	return nil
@@ -296,6 +317,104 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name,
 			"Status.SubnetID")
+	}
+	return nil
+}
+
+// resolveReferenceForBrokerNodeGroupInfo_SecurityGroups reads the resource referenced
+// from BrokerNodeGroupInfo.SecurityGroupRefs field and sets the BrokerNodeGroupInfo.SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForBrokerNodeGroupInfo_SecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Cluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.BrokerNodeGroupInfo != nil {
+		for _, f0iter := range ko.Spec.BrokerNodeGroupInfo.SecurityGroupRefs {
+			if f0iter != nil && f0iter.From != nil {
+				hasReferences = true
+				arr := f0iter.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: BrokerNodeGroupInfo.SecurityGroupRefs")
+				}
+				namespace, err := ackrt.ResolveCrossNamespaceReference(
+					ctx,
+					rm.cfg.EnableCrossNamespace,
+					&ko.Status.Conditions,
+					ackrt.CrossNamespaceRefKindResource,
+					ko.ObjectMeta.GetNamespace(),
+					arr.Namespace,
+					*arr.Name,
+				)
+				if err != nil {
+					return hasReferences, err
+				}
+				obj := &ec2apitypes.SecurityGroup{}
+				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+					return hasReferences, err
+				}
+				if ko.Spec.BrokerNodeGroupInfo.SecurityGroups == nil {
+					ko.Spec.BrokerNodeGroupInfo.SecurityGroups = make([]*string, 0, 1)
+				}
+				ko.Spec.BrokerNodeGroupInfo.SecurityGroups = append(ko.Spec.BrokerNodeGroupInfo.SecurityGroups, (*string)(obj.Status.ID))
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
 	}
 	return nil
 }

--- a/pkg/resource/serverless_cluster/references.go
+++ b/pkg/resource/serverless_cluster/references.go
@@ -39,6 +39,9 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -54,6 +57,14 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
 			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 {
 				ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnets = nil
+			}
+		}
+	}
+
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 {
+				ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = nil
 			}
 		}
 	}
@@ -89,6 +100,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -104,6 +121,14 @@ func validateReferenceFields(ko *svcapitypes.ServerlessCluster) error {
 		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
 			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs) > 0 && len(ko.Spec.Provisioned.BrokerNodeGroupInfo.ClientSubnets) > 0 {
 				return ackerr.ResourceReferenceAndIDNotSupportedFor("Provisioned.BrokerNodeGroupInfo.ClientSubnets", "Provisioned.BrokerNodeGroupInfo.ClientSubnetRefs")
+			}
+		}
+	}
+
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			if len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs) > 0 && len(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups) > 0 {
+				return ackerr.ResourceReferenceAndIDNotSupportedFor("Provisioned.BrokerNodeGroupInfo.SecurityGroups", "Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs")
 			}
 		}
 	}
@@ -302,6 +327,106 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name,
 			"Status.SubnetID")
+	}
+	return nil
+}
+
+// resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups reads the resource referenced
+// from Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs field and sets the Provisioned.BrokerNodeGroupInfo.SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForProvisioned_BrokerNodeGroupInfo_SecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ServerlessCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.Provisioned != nil {
+		if ko.Spec.Provisioned.BrokerNodeGroupInfo != nil {
+			for _, f0iter := range ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs {
+				if f0iter != nil && f0iter.From != nil {
+					hasReferences = true
+					arr := f0iter.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: Provisioned.BrokerNodeGroupInfo.SecurityGroupRefs")
+					}
+					namespace, err := ackrt.ResolveCrossNamespaceReference(
+						ctx,
+						rm.cfg.EnableCrossNamespace,
+						&ko.Status.Conditions,
+						ackrt.CrossNamespaceRefKindResource,
+						ko.ObjectMeta.GetNamespace(),
+						arr.Namespace,
+						*arr.Name,
+					)
+					if err != nil {
+						return hasReferences, err
+					}
+					obj := &ec2apitypes.SecurityGroup{}
+					if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					if ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups == nil {
+						ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = make([]*string, 0, 1)
+					}
+					ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups = append(ko.Spec.Provisioned.BrokerNodeGroupInfo.SecurityGroups, (*string)(obj.Status.ID))
+				}
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Add cross-resource references identified by the ACK scanner gap analysis tool.

### Changes
- `Cluster.BrokerNodeGroupInfo.SecurityGroups` → ec2 SecurityGroup
- `ServerlessCluster.Provisioned.BrokerNodeGroupInfo.SecurityGroups` → ec2 SecurityGroup

Note: the scanner also flagged `ConfigurationInfo.ARN` (Cluster and ServerlessCluster) → Configuration, but the code-generator rejects references whose leaf field name is a bare identifier suffix (`ARN`), so those could not be added.

### Testing
- Code generated with `make build-controller` (latest code-generator + runtime v0.60.0)
- Controller compiles: `go build -o bin/controller ./cmd/controller`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.