### PR TITLE
Add support for Cluster Policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-13T23:27:25Z"
+  build_date: "2026-08-14T19:40:07Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.5
   version: v0.62.1
-api_directory_checksum: cd670d6d49fcb5c514fb4e794e3ad7305e231452
+api_directory_checksum: 6edd1857298b91b588ae0669674e164f0a0abfb8
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: e30db951812ba1992876971ea3fdc320fc915335
+  file_checksum: eb10305b465f11904f811766459c57279fc046d0
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/cluster.go
+++ b/apis/v1alpha1/cluster.go
@@ -51,6 +51,8 @@ type ClusterSpec struct {
 	NumberOfBrokerNodes *int64 `json:"numberOfBrokerNodes"`
 	// The settings for open monitoring.
 	OpenMonitoring *OpenMonitoringInfo `json:"openMonitoring,omitempty"`
+	// The cluster policy.
+	Policy *string `json:"policy,omitempty"`
 	// Specifies if intelligent rebalancing should be turned on for the new MSK
 	// Provisioned cluster with Express brokers. By default, intelligent rebalancing
 	// status is ACTIVE for all new clusters.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -56,6 +56,15 @@ resources:
       terminal_codes:
         - BadRequestException
     fields:
+      # Policy is a JSON IAM-style cluster resource policy document managed via
+      # the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy APIs, which
+      # are outside the normal Create/Describe/Update lifecycle. Custom hooks
+      # read and reconcile this field.
+      Policy:
+        from:
+          operation: GetClusterPolicy
+          path: Policy
+        is_iam_policy: true
       Rebalancing:
         late_initialize:
           skip_incomplete_check: {}
@@ -136,7 +145,19 @@ resources:
           output_fields:
             ClusterName: Name
             ClusterType: Type
+    exceptions:
+      terminal_codes:
+        - BadRequestException
     fields:
+      # Policy is a JSON IAM-style cluster resource policy document managed via
+      # the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy APIs, which
+      # are outside the normal Create/Describe/Update lifecycle. Custom hooks
+      # read and reconcile this field.
+      Policy:
+        from:
+          operation: GetClusterPolicy
+          path: Policy
+        is_iam_policy: true
       AssociatedScramSecrets:
         type: "[]*string"
         references:

--- a/apis/v1alpha1/serverless_cluster.go
+++ b/apis/v1alpha1/serverless_cluster.go
@@ -27,6 +27,8 @@ type ServerlessClusterSpec struct {
 	// The name of the cluster.
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
+	// The cluster policy.
+	Policy *string `json:"policy,omitempty"`
 	// Information about the provisioned cluster.
 	Provisioned *ProvisionedRequest `json:"provisioned,omitempty"`
 	// Information about the serverless cluster.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -826,6 +826,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(OpenMonitoringInfo)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Policy != nil {
+		in, out := &in.Policy, &out.Policy
+		*out = new(string)
+		**out = **in
+	}
 	if in.Rebalancing != nil {
 		in, out := &in.Rebalancing, &out.Rebalancing
 		*out = new(Rebalancing)
@@ -2569,6 +2574,11 @@ func (in *ServerlessClusterSpec) DeepCopyInto(out *ServerlessClusterSpec) {
 	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
+	if in.Policy != nil {
+		in, out := &in.Policy, &out.Policy
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_clusters.yaml
@@ -337,6 +337,9 @@ spec:
                         type: object
                     type: object
                 type: object
+              policy:
+                description: The cluster policy.
+                type: string
               rebalancing:
                 description: |-
                   Specifies if intelligent rebalancing should be turned on for the new MSK

--- a/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/config/crd/bases/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -65,6 +65,9 @@ spec:
               name:
                 description: The name of the cluster.
                 type: string
+              policy:
+                description: The cluster policy.
+                type: string
               provisioned:
                 description: Information about the provisioned cluster.
                 properties:

--- a/generator.yaml
+++ b/generator.yaml
@@ -56,6 +56,15 @@ resources:
       terminal_codes:
         - BadRequestException
     fields:
+      # Policy is a JSON IAM-style cluster resource policy document managed via
+      # the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy APIs, which
+      # are outside the normal Create/Describe/Update lifecycle. Custom hooks
+      # read and reconcile this field.
+      Policy:
+        from:
+          operation: GetClusterPolicy
+          path: Policy
+        is_iam_policy: true
       Rebalancing:
         late_initialize:
           skip_incomplete_check: {}
@@ -136,7 +145,19 @@ resources:
           output_fields:
             ClusterName: Name
             ClusterType: Type
+    exceptions:
+      terminal_codes:
+        - BadRequestException
     fields:
+      # Policy is a JSON IAM-style cluster resource policy document managed via
+      # the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy APIs, which
+      # are outside the normal Create/Describe/Update lifecycle. Custom hooks
+      # read and reconcile this field.
+      Policy:
+        from:
+          operation: GetClusterPolicy
+          path: Policy
+        is_iam_policy: true
       AssociatedScramSecrets:
         type: "[]*string"
         references:

--- a/helm/crds/kafka.services.k8s.aws_clusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_clusters.yaml
@@ -337,6 +337,9 @@ spec:
                         type: object
                     type: object
                 type: object
+              policy:
+                description: The cluster policy.
+                type: string
               rebalancing:
                 description: |-
                   Specifies if intelligent rebalancing should be turned on for the new MSK

--- a/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
+++ b/helm/crds/kafka.services.k8s.aws_serverlessclusters.yaml
@@ -65,6 +65,9 @@ spec:
               name:
                 description: The name of the cluster.
                 type: string
+              policy:
+                description: The cluster policy.
+                type: string
               provisioned:
                 description: Information about the provisioned cluster.
                 properties:

--- a/pkg/resource/cluster/delta.go
+++ b/pkg/resource/cluster/delta.go
@@ -422,6 +422,13 @@ func newResourceDelta(
 			}
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
+		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
+			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Rebalancing, b.ko.Spec.Rebalancing) {
 		delta.Add("Spec.Rebalancing", a.ko.Spec.Rebalancing, b.ko.Spec.Rebalancing)
 	} else if a.ko.Spec.Rebalancing != nil && b.ko.Spec.Rebalancing != nil {

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/kafka"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	smithy "github.com/aws/smithy-go"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -160,6 +161,15 @@ func (rm *resourceManager) customUpdate(
 	}
 
 	switch {
+	case delta.DifferentAt("Spec.Policy"):
+		// Pass updatedRes (the object customUpdate returns) so the synced
+		// condition set inside syncClusterPolicy lands on the returned
+		// resource, matching the Spec.AssociatedSCRAMSecrets branch below.
+		if err = rm.syncClusterPolicy(ctx, updatedRes, latest); err != nil {
+			return updatedRes, err
+		}
+		return updatedRes, requeueAfterAsyncUpdate()
+
 	case delta.DifferentAt("Spec.Tags"):
 		if err = sync.Tags(
 			ctx,
@@ -828,6 +838,112 @@ func (rm *resourceManager) setBootstrapBrokerStringInformations(ctx context.Cont
 	r.Status.BootstrapBrokerStringVPCConnectivitySASLIAM = output.BootstrapBrokerStringVpcConnectivitySaslIam
 	r.Status.BootstrapBrokerStringVPCConnectivitySASLSCRAM = output.BootstrapBrokerStringVpcConnectivitySaslScram
 	r.Status.BootstrapBrokerStringVPCConnectivityTLS = output.BootstrapBrokerStringVpcConnectivityTls
+	return nil
+}
+
+// setClusterPolicy fetches the cluster resource policy via GetClusterPolicy
+// and sets ko.Spec.Policy accordingly. A NotFoundException means no policy is
+// currently attached, in which case Spec.Policy is set to nil and the error is
+// swallowed (it must not surface as a ReadOne 404 for the Cluster).
+func (rm *resourceManager) setClusterPolicy(
+	ctx context.Context,
+	ko *svcapitypes.Cluster,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setClusterPolicy")
+	defer func() { exit(err) }()
+
+	resp, err := rm.sdkapi.GetClusterPolicy(ctx, &svcsdk.GetClusterPolicyInput{
+		ClusterArn: (*string)(ko.Status.ACKResourceMetadata.ARN),
+	})
+	rm.metrics.RecordAPICall("GET", "GetClusterPolicy", err)
+	if err != nil {
+		if isClusterPolicyNotFound(err) {
+			ko.Spec.Policy = nil
+			return nil
+		}
+		return err
+	}
+	ko.Spec.Policy = resp.Policy
+	return nil
+}
+
+// isClusterPolicyNotFound returns true when the supplied error is a MSK
+// NotFoundException, which GetClusterPolicy returns when no policy is attached.
+func isClusterPolicyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
+		return awsErr.ErrorCode() == "NotFoundException"
+	}
+	return false
+}
+
+// syncClusterPolicy reconciles the cluster resource policy with the desired
+// state using the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy side
+// APIs. The policy version is fetched fresh via GetClusterPolicy immediately
+// before the Put so the (policy-specific) CurrentVersion is threaded correctly.
+// Note: the policy CurrentVersion is distinct from Status.CurrentVersion (the
+// cluster version used by the UpdateBroker* APIs).
+func (rm *resourceManager) syncClusterPolicy(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncClusterPolicy")
+	defer func() { exit(err) }()
+
+	clusterARN := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	// Fetch the current policy and its version. A NotFoundException means no
+	// policy currently exists, in which case the version is nil (required on
+	// first creation).
+	var currentVersion *string
+	policyExists := false
+	getResp, err := rm.sdkapi.GetClusterPolicy(ctx, &svcsdk.GetClusterPolicyInput{
+		ClusterArn: clusterARN,
+	})
+	rm.metrics.RecordAPICall("GET", "GetClusterPolicy", err)
+	if err != nil {
+		if !isClusterPolicyNotFound(err) {
+			return err
+		}
+	} else {
+		currentVersion = getResp.CurrentVersion
+		policyExists = getResp.Policy != nil
+	}
+
+	desiredPolicy := desired.ko.Spec.Policy
+	if desiredPolicy != nil && strings.TrimSpace(*desiredPolicy) != "" {
+		_, err = rm.sdkapi.PutClusterPolicy(ctx, &svcsdk.PutClusterPolicyInput{
+			ClusterArn:     clusterARN,
+			Policy:         desiredPolicy,
+			CurrentVersion: currentVersion,
+		})
+		rm.metrics.RecordAPICall("UPDATE", "PutClusterPolicy", err)
+		if err != nil {
+			return err
+		}
+		message := "kafka is updating cluster policy"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &message, nil)
+		return nil
+	}
+
+	// Desired policy is empty; delete any existing policy.
+	if policyExists {
+		_, err = rm.sdkapi.DeleteClusterPolicy(ctx, &svcsdk.DeleteClusterPolicyInput{
+			ClusterArn: clusterARN,
+		})
+		rm.metrics.RecordAPICall("DELETE", "DeleteClusterPolicy", err)
+		if err != nil {
+			return err
+		}
+		message := "kafka is deleting cluster policy"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &message, nil)
+	}
 	return nil
 }
 

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -407,6 +407,12 @@ func (rm *resourceManager) sdkFind(
 		if err != nil {
 			return nil, err
 		}
+		// Cluster resource policies are managed via a separate side-API
+		// (GetClusterPolicy). A NotFoundException simply means no policy is
+		// attached and must not surface as a ReadOne 404 for the Cluster.
+		if err = rm.setClusterPolicy(ctx, ko); err != nil {
+			return nil, err
+		}
 	}
 	return &resource{ko}, nil
 }

--- a/pkg/resource/serverless_cluster/delta.go
+++ b/pkg/resource/serverless_cluster/delta.go
@@ -60,6 +60,13 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
+		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
+			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Provisioned, b.ko.Spec.Provisioned) {
 		delta.Add("Spec.Provisioned", a.ko.Spec.Provisioned, b.ko.Spec.Provisioned)
 	} else if a.ko.Spec.Provisioned != nil && b.ko.Spec.Provisioned != nil {

--- a/pkg/resource/serverless_cluster/hooks.go
+++ b/pkg/resource/serverless_cluster/hooks.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/kafka"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	smithy "github.com/aws/smithy-go"
 	corev1 "k8s.io/api/core/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
@@ -174,6 +175,15 @@ func (rm *resourceManager) customUpdate(
 
 	// handle provisioned cluster updates
 	switch {
+	case delta.DifferentAt("Spec.Policy"):
+		// Pass updatedRes (the object customUpdate returns) so the synced
+		// condition set inside syncClusterPolicy lands on the returned
+		// resource, matching the Spec.AssociatedSCRAMSecrets branch below.
+		if err = rm.syncClusterPolicy(ctx, updatedRes, latest); err != nil {
+			return updatedRes, err
+		}
+		return updatedRes, requeueAfterAsyncUpdate()
+
 	case delta.DifferentAt("Spec.Provisioned.ClientAuthentication"):
 		return rm.updateClientAuthentication(ctx, updatedRes, latest)
 	case delta.DifferentAt("Spec.AssociatedSCRAMSecrets"):
@@ -885,6 +895,112 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	return res, nil
 }
 
+// setClusterPolicy fetches the cluster resource policy via GetClusterPolicy
+// and sets ko.Spec.Policy accordingly. A NotFoundException means no policy is
+// currently attached, in which case Spec.Policy is set to nil and the error is
+// swallowed (it must not surface as a ReadOne 404 for the ServerlessCluster).
+func (rm *resourceManager) setClusterPolicy(
+	ctx context.Context,
+	ko *svcapitypes.ServerlessCluster,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setClusterPolicy")
+	defer func() { exit(err) }()
+
+	resp, err := rm.sdkapi.GetClusterPolicy(ctx, &svcsdk.GetClusterPolicyInput{
+		ClusterArn: (*string)(ko.Status.ACKResourceMetadata.ARN),
+	})
+	rm.metrics.RecordAPICall("GET", "GetClusterPolicy", err)
+	if err != nil {
+		if isClusterPolicyNotFound(err) {
+			ko.Spec.Policy = nil
+			return nil
+		}
+		return err
+	}
+	ko.Spec.Policy = resp.Policy
+	return nil
+}
+
+// isClusterPolicyNotFound returns true when the supplied error is a MSK
+// NotFoundException, which GetClusterPolicy returns when no policy is attached.
+func isClusterPolicyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
+		return awsErr.ErrorCode() == "NotFoundException"
+	}
+	return false
+}
+
+// syncClusterPolicy reconciles the cluster resource policy with the desired
+// state using the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy side
+// APIs. The policy version is fetched fresh via GetClusterPolicy immediately
+// before the Put so the (policy-specific) CurrentVersion is threaded correctly.
+// Note: the policy CurrentVersion is distinct from Status.CurrentVersion (the
+// cluster version used by the UpdateBroker* APIs).
+func (rm *resourceManager) syncClusterPolicy(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncClusterPolicy")
+	defer func() { exit(err) }()
+
+	clusterARN := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	// Fetch the current policy and its version. A NotFoundException means no
+	// policy currently exists, in which case the version is nil (required on
+	// first creation).
+	var currentVersion *string
+	policyExists := false
+	getResp, err := rm.sdkapi.GetClusterPolicy(ctx, &svcsdk.GetClusterPolicyInput{
+		ClusterArn: clusterARN,
+	})
+	rm.metrics.RecordAPICall("GET", "GetClusterPolicy", err)
+	if err != nil {
+		if !isClusterPolicyNotFound(err) {
+			return err
+		}
+	} else {
+		currentVersion = getResp.CurrentVersion
+		policyExists = getResp.Policy != nil
+	}
+
+	desiredPolicy := desired.ko.Spec.Policy
+	if desiredPolicy != nil && strings.TrimSpace(*desiredPolicy) != "" {
+		_, err = rm.sdkapi.PutClusterPolicy(ctx, &svcsdk.PutClusterPolicyInput{
+			ClusterArn:     clusterARN,
+			Policy:         desiredPolicy,
+			CurrentVersion: currentVersion,
+		})
+		rm.metrics.RecordAPICall("UPDATE", "PutClusterPolicy", err)
+		if err != nil {
+			return err
+		}
+		message := "kafka is updating cluster policy"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &message, nil)
+		return nil
+	}
+
+	// Desired policy is empty; delete any existing policy.
+	if policyExists {
+		_, err = rm.sdkapi.DeleteClusterPolicy(ctx, &svcsdk.DeleteClusterPolicyInput{
+			ClusterArn: clusterARN,
+		})
+		rm.metrics.RecordAPICall("DELETE", "DeleteClusterPolicy", err)
+		if err != nil {
+			return err
+		}
+		message := "kafka is deleting cluster policy"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &message, nil)
+	}
+	return nil
+}
+
 func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
 	if a.ko.Spec.Provisioned != nil && b.ko.Spec.Provisioned != nil {
 		// MSK's DescribeCluster API returns LoggingInfo as nil when all broker
@@ -938,6 +1054,7 @@ func customPreCompare(_ *ackcompare.Delta, a, b *resource) {
 			a.ko.Spec.Provisioned.OpenMonitoring = b.ko.Spec.Provisioned.OpenMonitoring
 		}
 	}
+
 }
 
 func loggingDisabled(li *svcapitypes.LoggingInfo) bool {

--- a/pkg/resource/serverless_cluster/sdk.go
+++ b/pkg/resource/serverless_cluster/sdk.go
@@ -415,6 +415,14 @@ func (rm *resourceManager) sdkFind(
 		return &resource{ko}, nil
 	}
 
+	// Cluster resource policies apply to both provisioned and serverless
+	// clusters, so this is fetched independently of the SCRAM secret guard
+	// below. A NotFoundException simply means no policy is attached and must
+	// not surface as a ReadOne 404 for the ServerlessCluster.
+	if err = rm.setClusterPolicy(ctx, ko); err != nil {
+		return nil, err
+	}
+
 	// Unprovisioned Clusters do not use Scram Secrets
 	if ko.Spec.Provisioned != nil {
 		ko.Spec.AssociatedSCRAMSecrets, err = rm.getAssociatedScramSecrets(ctx, &resource{ko})
@@ -968,6 +976,18 @@ func (rm *resourceManager) updateConditions(
 // and if the exception indicates that it is a Terminal exception
 // 'Terminal' exception are specified in generator configuration
 func (rm *resourceManager) terminalAWSError(err error) bool {
-	// No terminal_errors specified for this resource in generator config
-	return false
+	if err == nil {
+		return false
+	}
+
+	var terminalErr smithy.APIError
+	if !errors.As(err, &terminalErr) {
+		return false
+	}
+	switch terminalErr.ErrorCode() {
+	case "BadRequestException":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T23:27:25Z"
+	ACKGenerateBuildDate = "2026-08-14T19:40:07Z"
 )

--- a/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
@@ -31,4 +31,10 @@
 		if err != nil {
 			return nil, err
 		}
+		// Cluster resource policies are managed via a separate side-API
+		// (GetClusterPolicy). A NotFoundException simply means no policy is
+		// attached and must not surface as a ReadOne 404 for the Cluster.
+		if err = rm.setClusterPolicy(ctx, ko); err != nil {
+			return nil, err
+		}
 	}

--- a/templates/hooks/serverless_cluster/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/serverless_cluster/sdk_read_one_post_set_output.go.tpl
@@ -21,6 +21,14 @@
 		return &resource{ko}, nil
 	}
 
+	// Cluster resource policies apply to both provisioned and serverless
+	// clusters, so this is fetched independently of the SCRAM secret guard
+	// below. A NotFoundException simply means no policy is attached and must
+	// not surface as a ReadOne 404 for the ServerlessCluster.
+	if err = rm.setClusterPolicy(ctx, ko); err != nil {
+		return nil, err
+	}
+
 	// Unprovisioned Clusters do not use Scram Secrets
 	if ko.Spec.Provisioned != nil {
 		ko.Spec.AssociatedSCRAMSecrets, err = rm.getAssociatedScramSecrets(ctx, &resource{ko})

--- a/test/e2e/cluster.py
+++ b/test/e2e/cluster.py
@@ -200,3 +200,18 @@ def get_tags(cluster_arn):
         return resp["Tags"]
     except c.exceptions.NotFoundException:
         return None
+
+
+def get_cluster_policy(cluster_arn):
+    """Returns the cluster resource policy document (a JSON string) attached to
+    the supplied Cluster.
+
+    If no policy is attached (GetClusterPolicy raises NotFoundException),
+    returns None.
+    """
+    c = boto3.client("kafka")
+    try:
+        resp = c.get_cluster_policy(ClusterArn=cluster_arn)
+        return resp.get("Policy")
+    except c.exceptions.NotFoundException:
+        return None

--- a/test/e2e/resources/cluster_policy.yaml
+++ b/test/e2e/resources/cluster_policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: Cluster
+metadata:
+  name: $CLUSTER_NAME
+spec:
+  name: $CLUSTER_NAME
+  brokerNodeGroupInfo:
+    instanceType: "kafka.t3.small"
+    # NOTE(jaypipes): Clusters require at least 2 subnets.
+    clientSubnets:
+      - $SUBNET_ID_1
+      - $SUBNET_ID_2
+    storageInfo:
+      ebsStorageInfo:
+        volumeSize: 10
+  kafkaVersion: "3.9.x"
+  # NOTE(jaypipes): Number of broker nodes need to be a multiple of the number
+  # of subnets
+  numberOfBrokerNodes: 2

--- a/test/e2e/resources/serverlesscluster_policy.yaml
+++ b/test/e2e/resources/serverlesscluster_policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: ServerlessCluster
+metadata:
+  name: $SERVERLESS_CLUSTER_NAME
+spec:
+  name: $SERVERLESS_CLUSTER_NAME
+  serverless:
+    vpcConfigs:
+    - subnetIDs:
+      - $SUBNET_ID_1
+      - $SUBNET_ID_2
+    clientAuthentication:
+      sasl:
+        iam:
+          enabled: true

--- a/test/e2e/serverlesscluster.py
+++ b/test/e2e/serverlesscluster.py
@@ -198,3 +198,18 @@ def get_tags(cluster_arn):
         return resp["Tags"]
     except c.exceptions.NotFoundException:
         return None
+
+
+def get_cluster_policy(cluster_arn):
+    """Returns the cluster resource policy document (a JSON string) attached to
+    the supplied ClusterV2.
+
+    If no policy is attached (GetClusterPolicy raises NotFoundException),
+    returns None.
+    """
+    c = boto3.client("kafka")
+    try:
+        resp = c.get_cluster_policy(ClusterArn=cluster_arn)
+        return resp.get("Policy")
+    except c.exceptions.NotFoundException:
+        return None

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -13,11 +13,13 @@
 
 """Integration tests for the MSK Cluster resource"""
 
+import json
 import logging
 import time
 
 import pytest
 
+from acktest.aws.identity import get_account_id, get_region
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
@@ -27,6 +29,23 @@ from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.common.types import CLUSTER_RESOURCE_PLURAL
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import cluster
+
+
+def _cluster_policy_doc(principal_arn: str, actions) -> dict:
+    """Builds a valid MSK cluster resource policy document granting the
+    supplied principal the supplied kafka actions on the cluster."""
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": principal_arn},
+                "Action": actions,
+                "Resource": "*",
+            }
+        ],
+    }
+
 
 CREATE_WAIT_AFTER_SECONDS = 180
 DELETE_WAIT_SECONDS = 300
@@ -837,3 +856,151 @@ class TestExpressCluster:
         # Verify via AWS API
         aws_cluster = cluster.get_by_arn(cluster_arn)
         assert aws_cluster["Rebalancing"]["Status"] == "ACTIVE"
+
+
+@pytest.fixture(scope="module")
+def policy_cluster():
+    cluster_name = random_suffix_name("ack-cluster-policy", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+
+    resource_data = load_resource(
+        "cluster_policy",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+    cluster.wait_until_deleted(cluster_name)
+
+
+@service_marker
+@pytest.mark.canary
+class TestClusterPolicy:
+    """Verifies the Cluster resource policy lifecycle managed via the
+    GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy side APIs.
+    """
+
+    def test_cluster_policy_lifecycle(self, policy_cluster):
+        ref, _ = policy_cluster
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert "status" in cr
+        assert "ackResourceMetadata" in cr["status"]
+        assert "arn" in cr["status"]["ackResourceMetadata"]
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        cluster.wait_until(
+            cluster_arn,
+            cluster.state_matches("ACTIVE"),
+        )
+
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        condition.assert_synced(ref)
+
+        # No policy is attached at creation time.
+        assert cluster.get_cluster_policy(cluster_arn) is None
+
+        # The policy principal is the CI account root, which always exists.
+        account_id = get_account_id()
+        principal_arn = f"arn:aws:iam::{account_id}:root"
+
+        # Attach a policy via spec.policy and confirm it is applied.
+        policy_doc = _cluster_policy_doc(
+            principal_arn,
+            ["kafka:CreateVpcConnection", "kafka:GetBootstrapBrokers"],
+        )
+        updates = {"spec": {"policy": json.dumps(policy_doc)}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        aws_policy = cluster.get_cluster_policy(cluster_arn)
+        assert aws_policy is not None
+        assert json.loads(aws_policy) == policy_doc
+
+        # Confirm the resource does not perpetually diff: it stays Synced=True
+        # across subsequent reconciles even though key ordering/whitespace of
+        # the stored document may differ from the desired document.
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+        )
+
+        # Modify the policy (validates policy version threading in the Put).
+        modified_doc = _cluster_policy_doc(
+            principal_arn,
+            "kafka:GetBootstrapBrokers",
+        )
+        updates = {"spec": {"policy": json.dumps(modified_doc)}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        aws_policy = cluster.get_cluster_policy(cluster_arn)
+        assert aws_policy is not None
+        assert json.loads(aws_policy) == modified_doc
+
+        # Remove the policy (validates DeleteClusterPolicy path).
+        updates = {"spec": {"policy": None}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        # GetClusterPolicy now returns NotFound.
+        assert cluster.get_cluster_policy(cluster_arn) is None
+
+        # The resource stays Synced=True with no perpetual diff after deletion.
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+        )

--- a/test/e2e/tests/test_serverless_cluster.py
+++ b/test/e2e/tests/test_serverless_cluster.py
@@ -13,11 +13,13 @@
 
 """Integration tests for the MSK ServerlessCluster resource"""
 
+import json
 import logging
 import time
 
 import pytest
 
+from acktest.aws.identity import get_account_id, get_region
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
@@ -27,6 +29,23 @@ from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.common.types import SERVERLESSCLUSTER_RESOURCE_PLURAL
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import serverlesscluster
+
+
+def _cluster_policy_doc(principal_arn: str, actions) -> dict:
+    """Builds a valid MSK cluster resource policy document granting the
+    supplied principal the supplied kafka actions on the cluster."""
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": principal_arn},
+                "Action": actions,
+                "Resource": "*",
+            }
+        ],
+    }
+
 
 CREATE_WAIT_AFTER_SECONDS = 180
 DELETE_WAIT_SECONDS = 300
@@ -776,3 +795,153 @@ class TestExpressProvisionedCluster:
         # Verify via AWS API
         aws_cluster = serverlesscluster.get_by_arn(cluster_arn)
         assert aws_cluster["Provisioned"]["Rebalancing"]["Status"] == "ACTIVE"
+
+
+@pytest.fixture(scope="module")
+def policy_serverless_cluster():
+    cluster_name = random_suffix_name("ack-srvls-policy", 24)
+
+    resources = get_bootstrap_resources()
+    # Serverless MSK (and its multi-VPC connectivity) requires a VPC with DNS
+    # hostnames enabled, so use the DNS-hostnames-enabled VpcConnectionVPC.
+    vpc = resources.VpcConnectionVPC
+    subnet_id_1 = vpc.public_subnets.subnet_ids[0]
+    subnet_id_2 = vpc.public_subnets.subnet_ids[1]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["SERVERLESS_CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_id_1
+    replacements["SUBNET_ID_2"] = subnet_id_2
+
+    resource_data = load_resource(
+        "serverlesscluster_policy",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        SERVERLESSCLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_SECONDS,
+    )
+    assert deleted
+    serverlesscluster.wait_until_deleted(cluster_name)
+
+
+@service_marker
+@pytest.mark.canary
+class TestServerlessClusterPolicy:
+    """Verifies the ServerlessCluster resource policy lifecycle managed via the
+    GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy side APIs.
+    """
+
+    def test_cluster_policy_lifecycle(self, policy_serverless_cluster):
+        ref, _ = policy_serverless_cluster
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert "status" in cr
+        assert "ackResourceMetadata" in cr["status"]
+        assert "arn" in cr["status"]["ackResourceMetadata"]
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        serverlesscluster.wait_until(
+            cluster_arn,
+            serverlesscluster.state_matches("ACTIVE"),
+        )
+
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        condition.assert_synced(ref)
+
+        # No policy is attached at creation time.
+        assert serverlesscluster.get_cluster_policy(cluster_arn) is None
+
+        # The policy principal is the CI account root, which always exists.
+        account_id = get_account_id()
+        principal_arn = f"arn:aws:iam::{account_id}:root"
+
+        # Attach a policy via spec.policy and confirm it is applied.
+        policy_doc = _cluster_policy_doc(
+            principal_arn,
+            ["kafka:CreateVpcConnection", "kafka:GetBootstrapBrokers"],
+        )
+        updates = {"spec": {"policy": json.dumps(policy_doc)}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        aws_policy = serverlesscluster.get_cluster_policy(cluster_arn)
+        assert aws_policy is not None
+        assert json.loads(aws_policy) == policy_doc
+
+        # Confirm the resource does not perpetually diff: it stays Synced=True
+        # across subsequent reconciles even though key ordering/whitespace of
+        # the stored document may differ from the desired document.
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+        )
+
+        # Modify the policy (validates policy version threading in the Put).
+        modified_doc = _cluster_policy_doc(
+            principal_arn,
+            "kafka:GetBootstrapBrokers",
+        )
+        updates = {"spec": {"policy": json.dumps(modified_doc)}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        aws_policy = serverlesscluster.get_cluster_policy(cluster_arn)
+        assert aws_policy is not None
+        assert json.loads(aws_policy) == modified_doc
+
+        # Remove the policy (validates DeleteClusterPolicy path).
+        updates = {"spec": {"policy": None}}
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        # GetClusterPolicy now returns NotFound.
+        assert serverlesscluster.get_cluster_policy(cluster_arn) is None
+
+        # The resource stays Synced=True with no perpetual diff after deletion.
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+        )


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adds a spec.policy field to both Cluster and ServerlessCluster for managing MSK cluster resource policies, reconciled via the GetClusterPolicy/PutClusterPolicy/DeleteClusterPolicy side APIs (outside the normal CRUD lifecycle).

  Changes

  - generator.yaml: added Policy field (is_iam_policy: true) to both resources; added
  BadRequestException terminal code for ServerlessCluster.
  - Custom hooks: syncClusterPolicy (Put/Delete with fresh version fetch), setClusterPolicy
  (populates Spec.Policy on read, treats NotFound as "no policy"), and
  isClusterPolicyNotFound. Wired into customUpdate on Spec.Policy delta and into the read
  path.
  - Comparison: uses IAMPolicyDocumentEqual so semantically-equal policy documents (e.g.
  single-element Action array vs. string) don't cause a perpetual diff.
  - E2E tests: full policy lifecycle for both resources — attach, modify, clear — verified
  against AWS with no perpetual diff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
