### PR TITLE
feat: allow Cluster adoption by name

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-07T01:36:14Z"
+  build_date: "2026-08-11T16:31:32Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.4
   version: v0.62.0
 api_directory_checksum: cd670d6d49fcb5c514fb4e794e3ad7305e231452
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: e30db951812ba1992876971ea3fdc320fc915335
+  file_checksum: 36eb6c65399cf171f64177f5169d84a38a006a77
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -33,6 +33,10 @@ resources:
           input_fields:
             ClusterName: Name
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -33,6 +33,10 @@ resources:
           input_fields:
             ClusterName: Name
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -1023,3 +1023,61 @@ func int32OrNil(num *int64) *int32 {
 
 	return aws.Int32(int32(*num))
 }
+
+// getClusterARN looks up the ARN of the cluster named by the supplied
+// resource's Spec.Name. MSK cluster ARNs embed a service-generated UUID
+// (arn:aws:kafka:<region>:<account>:cluster/<name>/<uuid>-<n>), so they cannot
+// be constructed from the name alone and must be read back from the API.
+//
+// Cluster names are unique within an account and region, so at most one
+// cluster can match. Returns nil (without error) when no cluster matches,
+// which callers translate into ackerr.NotFound.
+func (rm *resourceManager) getClusterARN(
+	ctx context.Context,
+	r *resource,
+) (arn *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getClusterARN")
+	defer func() { exit(err) }()
+
+	// Spec.Name is required for create, but an adopted resource may be
+	// identified solely by its ARN, in which case there is nothing to look up.
+	if r.ko.Spec.Name == nil {
+		return nil, nil
+	}
+
+	input := &svcsdk.ListClustersInput{
+		ClusterNameFilter: r.ko.Spec.Name,
+	}
+
+	paginator := svcsdk.NewListClustersPaginator(rm.sdkapi, input)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListClusters", err)
+		if err != nil {
+			return nil, err
+		}
+		if arn := findClusterARNByName(resp.ClusterInfoList, *r.ko.Spec.Name); arn != nil {
+			return arn, nil
+		}
+	}
+	return nil, nil
+}
+
+// findClusterARNByName returns the ARN of the cluster named exactly name, or
+// nil if the supplied page holds no such cluster.
+func findClusterARNByName(
+	clusters []svcsdktypes.ClusterInfo,
+	name string,
+) *string {
+	for _, c := range clusters {
+		// ClusterNameFilter is a prefix filter, so a filter of "abc" also
+		// returns a cluster named "abcd". This exact-match check is what makes
+		// the lookup correct.
+		if c.ClusterName == nil || *c.ClusterName != name {
+			continue
+		}
+		return c.ClusterArn
+	}
+	return nil
+}

--- a/pkg/resource/cluster/hooks_test.go
+++ b/pkg/resource/cluster/hooks_test.go
@@ -1,0 +1,116 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+func Test_findClusterARNByName(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters []svcsdktypes.ClusterInfo
+		lookup   string
+		want     *string
+	}{
+		{
+			name:     "no clusters",
+			clusters: nil,
+			lookup:   "my-cluster",
+			want:     nil,
+		},
+		{
+			name: "exact match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/abc-1"),
+		},
+		{
+			name: "prefix match is not an exact match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster-2"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster-2/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "exact match found alongside prefix matches",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster-2"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster-2/abc-1"),
+				},
+				{
+					ClusterName: aws.String("my-cluster"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/def-2"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/def-2"),
+		},
+		{
+			name: "shorter name than the filter does not match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-clust"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-clust/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "name differing only by case does not match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("MY-CLUSTER"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/MY-CLUSTER/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "nil cluster name is skipped",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: nil,
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/unknown/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findClusterARNByName(tt.clusters, tt.lookup)
+			if aws.ToString(got) != aws.ToString(tt.want) {
+				t.Errorf("findClusterARNByName() = %v, want %v",
+					aws.ToString(got), aws.ToString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/resource/cluster/resource.go
+++ b/pkg/resource/cluster/resource.go
@@ -97,6 +97,22 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}
+
 	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -64,6 +64,27 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+
+	// DescribeCluster is keyed on the cluster ARN, which is only known after
+	// creation. When the ARN is absent but the user gave us a name -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	r.ko = r.ko.DeepCopy()
+	if rm.requiredFieldsMissingFromReadOneInput(r) {
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}
+
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/templates/hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/cluster/pre_populate_resource_from_annotation.go.tpl
@@ -1,0 +1,15 @@
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}

--- a/templates/hooks/cluster/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,20 @@
+
+	// DescribeCluster is keyed on the cluster ARN, which is only known after
+	// creation. When the ARN is absent but the user gave us a name -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	r.ko = r.ko.DeepCopy()
+	if rm.requiredFieldsMissingFromReadOneInput(r) {
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}

--- a/test/e2e/resources/cluster_adopt_by_name.yaml
+++ b/test/e2e/resources/cluster_adopt_by_name.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: Cluster
+metadata:
+  name: $CLUSTER_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt
+    services.k8s.aws/adoption-fields: "$ADOPTION_FIELDS"
+spec:
+  name: $CLUSTER_NAME

--- a/test/e2e/resources/cluster_adopt_source.yaml
+++ b/test/e2e/resources/cluster_adopt_source.yaml
@@ -1,0 +1,18 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: Cluster
+metadata:
+  name: $CLUSTER_NAME
+  annotations:
+    services.k8s.aws/deletion-policy: retain
+spec:
+  name: $CLUSTER_NAME
+  brokerNodeGroupInfo:
+    instanceType: "kafka.t3.small"
+    clientSubnets:
+      - $SUBNET_ID_1
+      - $SUBNET_ID_2
+    storageInfo:
+      ebsStorageInfo:
+        volumeSize: 10
+  kafkaVersion: "3.9.x"
+  numberOfBrokerNodes: 2

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -694,6 +694,93 @@ class TestClusterVPCConnectivity:
 
 
 @pytest.fixture(scope="module")
+def adopt_by_name_cluster():
+    cluster_name = random_suffix_name("ack-adopt-name", 24)
+
+    resources = get_bootstrap_resources()
+    vpc = resources.ClusterVPC
+    subnet_ids = vpc.public_subnets.subnet_ids
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CLUSTER_NAME"] = cluster_name
+    replacements["SUBNET_ID_1"] = subnet_ids[0]
+    replacements["SUBNET_ID_2"] = subnet_ids[1]
+
+    resource_data = load_resource(
+        "cluster_adopt_source",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CLUSTER_RESOURCE_PLURAL,
+        cluster_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+
+    try:
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+        cr = k8s.get_resource(ref)
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+        cluster.wait_until(cluster_arn, cluster.state_matches("ACTIVE"))
+
+        # The retain deletion policy leaves the MSK cluster in place so the
+        # next CR can adopt it by name.
+        _, deleted = k8s.delete_custom_resource(
+            ref,
+            period_length=DELETE_WAIT_SECONDS,
+        )
+        assert deleted
+
+        replacements["ADOPTION_FIELDS"] = f'{{\\"name\\": \\"{cluster_name}\\"}}'
+        resource_data = load_resource(
+            "cluster_adopt_by_name",
+            additional_replacements=replacements,
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+
+        yield (ref, cr, cluster_arn)
+    finally:
+        try:
+            k8s.delete_custom_resource(ref, period_length=DELETE_WAIT_SECONDS)
+        except Exception:
+            pass
+        cluster.wait_until_deleted(cluster_name)
+
+
+@service_marker
+@pytest.mark.canary
+class TestClusterAdoptByName:
+    def test_adopt_by_name(self, adopt_by_name_cluster):
+        ref, _, cluster_arn = adopt_by_name_cluster
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=LONG_UPDATE_WAIT,
+        )
+
+        cr = k8s.get_resource(ref)
+        assert cr["status"]["ackResourceMetadata"]["arn"] == cluster_arn
+        assert cr["status"]["state"] == "ACTIVE"
+        assert cr["spec"]["kafkaVersion"] == "3.9.x"
+        assert cr["spec"]["numberOfBrokerNodes"] == 2
+
+        aws_cluster = cluster.get_by_arn(cluster_arn)
+        assert aws_cluster is not None
+        assert aws_cluster["ClusterName"] == cr["spec"]["name"]
+
+
+@pytest.fixture(scope="module")
 def express_cluster():
     cluster_name = random_suffix_name("ack-express", 24)
 


### PR DESCRIPTION
Description of changes:
MSK cluster ARNs embed a service-generated UUID, so they cannot be known
before creation, which made GitOps-style adoption impractical. Adoption now
accepts {"name": "..."} in addition to {"arn": "..."}, and sdkFind resolves
a name to its ARN via ListClusters when the ARN is absent -- so annotation-free
adopt-or-create works too.

Resolves aws-controllers-k8s/community#2943

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
