### PR TITLE
feat: allow Cluster and ServerlessCluster adoption by name

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-14T19:40:07Z"
-  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
-  go_version: go1.26.5
-  version: v0.62.1
-api_directory_checksum: 6edd1857298b91b588ae0669674e164f0a0abfb8
+  build_date: "2026-08-18T16:43:27Z"
+  build_hash: d4aaca5e1dd6acfd81094936dc825ad30d2bbb39
+  go_version: go1.26.4
+  version: v0.62.1-4-gd4aaca5
+api_directory_checksum: 7111775ac8a1f5a266dd4e8544612c61246064fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: eb10305b465f11904f811766459c57279fc046d0
+  file_checksum: f6e4b6777be44ac86c4b8504bc4aea42a9dff64d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -21,6 +21,10 @@ resources:
     tags:
       ignore: true
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/configuration/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/configuration/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/configuration/sdk_read_one_post_set_output.go.tpl
   Cluster:
@@ -33,6 +37,10 @@ resources:
           input_fields:
             ClusterName: Name
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
@@ -258,6 +266,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/serverless_cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/serverless_cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/serverless_cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -17,14 +17,12 @@ package v1alpha1
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
 	_ = ackv1alpha1.AWSAccountID("")
 )
 

--- a/generator.yaml
+++ b/generator.yaml
@@ -21,6 +21,10 @@ resources:
     tags:
       ignore: true
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/configuration/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/configuration/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/configuration/sdk_read_one_post_set_output.go.tpl
   Cluster:
@@ -33,6 +37,10 @@ resources:
           input_fields:
             ClusterName: Name
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
@@ -258,6 +266,10 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
     hooks:
+      pre_populate_resource_from_annotation:
+        template_path: hooks/serverless_cluster/pre_populate_resource_from_annotation.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/serverless_cluster/sdk_read_one_pre_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/serverless_cluster/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws-controllers-k8s/ec2-controller v1.9.2
 	github.com/aws-controllers-k8s/runtime v0.62.0
 	github.com/aws-controllers-k8s/secretsmanager-controller v0.0.7
-	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.49.2
 	github.com/aws/smithy-go v1.24.2
@@ -19,6 +18,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.49.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.28.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.47 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.21 // indirect

--- a/pkg/adoption/lookup.go
+++ b/pkg/adoption/lookup.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package adoption
+
+import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+)
+
+// ShouldLookupARN returns true when the supplied resource has no ARN but does
+// carry an adoption-policy annotation.
+//
+// MSK identifies clusters and configurations by ARNs that embed a
+// service-generated UUID, so an ARN cannot be derived from the resource name
+// and has to be read back from the API. Resolving it costs a List call, so the
+// lookup is limited to resources whose owner opted in by setting
+// services.k8s.aws/adoption-policy. An ordinary resource being created for the
+// first time also has no ARN, and must not pay for a lookup that would find
+// nothing.
+func ShouldLookupARN(res acktypes.AWSResource) bool {
+	if res == nil {
+		return false
+	}
+
+	if arn := res.Identifiers().ARN(); arn != nil && *arn != ackv1alpha1.AWSResourceName("") {
+		return false
+	}
+
+	mo := res.MetaObject()
+	if mo == nil {
+		return false
+	}
+	return mo.GetAnnotations()[ackv1alpha1.AnnotationAdoptionPolicy] != ""
+}

--- a/pkg/adoption/lookup_test.go
+++ b/pkg/adoption/lookup_test.go
@@ -1,0 +1,137 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package adoption_test
+
+import (
+	"testing"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	svcapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/kafka-controller/pkg/adoption"
+)
+
+type fakeResource struct {
+	acktypes.AWSResource
+	arn         *ackv1alpha1.AWSResourceName
+	annotations map[string]string
+	nilMeta     bool
+}
+
+func (f *fakeResource) Identifiers() acktypes.AWSResourceIdentifiers {
+	return &fakeIdentifiers{arn: f.arn}
+}
+
+func (f *fakeResource) MetaObject() metav1.Object {
+	if f.nilMeta {
+		return nil
+	}
+	return &metav1.ObjectMeta{Annotations: f.annotations}
+}
+
+func (f *fakeResource) RuntimeObject() rtclient.Object {
+	return &svcapitypes.Cluster{}
+}
+
+type fakeIdentifiers struct {
+	arn *ackv1alpha1.AWSResourceName
+}
+
+func (f *fakeIdentifiers) ARN() *ackv1alpha1.AWSResourceName         { return f.arn }
+func (f *fakeIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID { return nil }
+func (f *fakeIdentifiers) Region() *ackv1alpha1.AWSRegion            { return nil }
+func (f *fakeIdentifiers) Partition() *ackv1alpha1.AWSPartition      { return nil }
+
+func arnPtr(s string) *ackv1alpha1.AWSResourceName {
+	arn := ackv1alpha1.AWSResourceName(s)
+	return &arn
+}
+
+func TestShouldLookupARN(t *testing.T) {
+	adoptPolicy := map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+	}
+	adoptOrCreatePolicy := map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt-or-create",
+	}
+
+	tests := []struct {
+		name string
+		res  acktypes.AWSResource
+		want bool
+	}{
+		{
+			name: "nil resource",
+			res:  nil,
+			want: false,
+		},
+		{
+			name: "no arn, adopt policy",
+			res:  &fakeResource{arn: nil, annotations: adoptPolicy},
+			want: true,
+		},
+		{
+			name: "no arn, adopt-or-create policy",
+			res:  &fakeResource{arn: nil, annotations: adoptOrCreatePolicy},
+			want: true,
+		},
+		{
+			name: "no arn, no adoption policy",
+			res:  &fakeResource{arn: nil, annotations: nil},
+			want: false,
+		},
+		{
+			name: "no arn, unrelated annotations only",
+			res: &fakeResource{arn: nil, annotations: map[string]string{
+				ackv1alpha1.AnnotationDeletionPolicy: "retain",
+			}},
+			want: false,
+		},
+		{
+			name: "no arn, empty adoption policy value",
+			res: &fakeResource{arn: nil, annotations: map[string]string{
+				ackv1alpha1.AnnotationAdoptionPolicy: "",
+			}},
+			want: false,
+		},
+		{
+			name: "arn already set, adopt policy",
+			res: &fakeResource{
+				arn:         arnPtr("arn:aws:kafka:us-west-2:123456789012:cluster/abc/uuid-1"),
+				annotations: adoptPolicy,
+			},
+			want: false,
+		},
+		{
+			name: "empty arn string is treated as absent",
+			res:  &fakeResource{arn: arnPtr(""), annotations: adoptPolicy},
+			want: true,
+		},
+		{
+			name: "nil meta object",
+			res:  &fakeResource{arn: nil, nilMeta: true},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adoption.ShouldLookupARN(tt.res); got != tt.want {
+				t.Errorf("ShouldLookupARN() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	svcapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/kafka-controller/pkg/adoption"
 	"github.com/aws-controllers-k8s/kafka-controller/pkg/sync"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -1138,4 +1139,68 @@ func int32OrNil(num *int64) *int32 {
 	}
 
 	return aws.Int32(int32(*num))
+}
+
+// shouldLookupARN returns true when the supplied resource needs its ARN
+// resolved from its name before a read can be attempted.
+func (rm *resourceManager) shouldLookupARN(r *resource) bool {
+	return adoption.ShouldLookupARN(r)
+}
+
+// getClusterARN looks up the ARN of the cluster named by the supplied
+// resource's Spec.Name. MSK cluster ARNs embed a service-generated UUID
+// (arn:aws:kafka:<region>:<account>:cluster/<name>/<uuid>-<n>), so they cannot
+// be constructed from the name alone and must be read back from the API.
+//
+// Cluster names are unique within an account and region, so at most one
+// cluster can match. Returns nil (without error) when no cluster matches,
+// which callers translate into ackerr.NotFound.
+func (rm *resourceManager) getClusterARN(
+	ctx context.Context,
+	r *resource,
+) (arn *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getClusterARN")
+	defer func() { exit(err) }()
+
+	// Spec.Name is required for create, but an adopted resource may be
+	// identified solely by its ARN, in which case there is nothing to look up.
+	if r.ko.Spec.Name == nil {
+		return nil, nil
+	}
+
+	input := &svcsdk.ListClustersInput{
+		ClusterNameFilter: r.ko.Spec.Name,
+	}
+
+	paginator := svcsdk.NewListClustersPaginator(rm.sdkapi, input)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListClusters", err)
+		if err != nil {
+			return nil, err
+		}
+		if arn := findClusterARNByName(resp.ClusterInfoList, *r.ko.Spec.Name); arn != nil {
+			return arn, nil
+		}
+	}
+	return nil, nil
+}
+
+// findClusterARNByName returns the ARN of the cluster named exactly name, or
+// nil if the supplied page holds no such cluster.
+func findClusterARNByName(
+	clusters []svcsdktypes.ClusterInfo,
+	name string,
+) *string {
+	for _, c := range clusters {
+		// ClusterNameFilter is a prefix filter, so a filter of "abc" also
+		// returns a cluster named "abcd". This exact-match check is what makes
+		// the lookup correct.
+		if c.ClusterName == nil || *c.ClusterName != name {
+			continue
+		}
+		return c.ClusterArn
+	}
+	return nil
 }

--- a/pkg/resource/cluster/hooks_test.go
+++ b/pkg/resource/cluster/hooks_test.go
@@ -1,0 +1,116 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+func Test_findClusterARNByName(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters []svcsdktypes.ClusterInfo
+		lookup   string
+		want     *string
+	}{
+		{
+			name:     "no clusters",
+			clusters: nil,
+			lookup:   "my-cluster",
+			want:     nil,
+		},
+		{
+			name: "exact match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/abc-1"),
+		},
+		{
+			name: "prefix match is not an exact match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster-2"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster-2/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "exact match found alongside prefix matches",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-cluster-2"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster-2/abc-1"),
+				},
+				{
+					ClusterName: aws.String("my-cluster"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/def-2"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-cluster/def-2"),
+		},
+		{
+			name: "shorter name than the filter does not match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("my-clust"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/my-clust/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "name differing only by case does not match",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: aws.String("MY-CLUSTER"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/MY-CLUSTER/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+		{
+			name: "nil cluster name is skipped",
+			clusters: []svcsdktypes.ClusterInfo{
+				{
+					ClusterName: nil,
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/unknown/abc-1"),
+				},
+			},
+			lookup: "my-cluster",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findClusterARNByName(tt.clusters, tt.lookup)
+			if aws.ToString(got) != aws.ToString(tt.want) {
+				t.Errorf("findClusterARNByName() = %v, want %v",
+					aws.ToString(got), aws.ToString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/resource/cluster/resource.go
+++ b/pkg/resource/cluster/resource.go
@@ -97,6 +97,22 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}
+
 	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -64,6 +64,27 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+
+	// DescribeCluster is keyed on the cluster ARN, which is only known after
+	// creation. When the owner opted into adoption but no ARN is set -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}
+
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/pkg/resource/configuration/hooks.go
+++ b/pkg/resource/configuration/hooks.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package configuration
+
+import (
+	"context"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/kafka"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+
+	"github.com/aws-controllers-k8s/kafka-controller/pkg/adoption"
+)
+
+// shouldLookupARN returns true when the supplied resource needs its ARN
+// resolved from its name before a read can be attempted.
+func (rm *resourceManager) shouldLookupARN(r *resource) bool {
+	return adoption.ShouldLookupARN(r)
+}
+
+// getConfigurationARN looks up the ARN of the configuration named by the
+// supplied resource's Spec.Name. MSK configuration ARNs embed a
+// service-generated UUID, so they cannot be constructed from the name alone and
+// must be read back from the API.
+//
+// Unlike ListClusters, ListConfigurations offers no name filter, so this walks
+// every configuration in the region. That is why callers gate the lookup on
+// shouldLookupARN: only a resource whose owner opted into adoption pays for it.
+//
+// Configuration names are unique within an account and region, so at most one
+// configuration can match. Returns nil (without error) when none matches, which
+// callers translate into ackerr.NotFound.
+func (rm *resourceManager) getConfigurationARN(
+	ctx context.Context,
+	r *resource,
+) (arn *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getConfigurationARN")
+	defer func() { exit(err) }()
+
+	// Spec.Name is required for create, but an adopted resource may be
+	// identified solely by its ARN, in which case there is nothing to look up.
+	if r.ko.Spec.Name == nil {
+		return nil, nil
+	}
+
+	paginator := svcsdk.NewListConfigurationsPaginator(
+		rm.sdkapi, &svcsdk.ListConfigurationsInput{},
+	)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListConfigurations", err)
+		if err != nil {
+			return nil, err
+		}
+		if arn := findConfigurationARNByName(resp.Configurations, *r.ko.Spec.Name); arn != nil {
+			return arn, nil
+		}
+	}
+	return nil, nil
+}
+
+// findConfigurationARNByName returns the ARN of the configuration named exactly
+// name, or nil if the supplied page holds no such configuration.
+func findConfigurationARNByName(
+	configurations []svcsdktypes.Configuration,
+	name string,
+) *string {
+	for _, c := range configurations {
+		if c.Name == nil || *c.Name != name {
+			continue
+		}
+		return c.Arn
+	}
+	return nil
+}

--- a/pkg/resource/configuration/hooks_test.go
+++ b/pkg/resource/configuration/hooks_test.go
@@ -1,0 +1,105 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+func Test_findConfigurationARNByName(t *testing.T) {
+	tests := []struct {
+		name           string
+		configurations []svcsdktypes.Configuration
+		lookup         string
+		want           *string
+	}{
+		{
+			name:           "no configurations",
+			configurations: nil,
+			lookup:         "abc",
+			want:           nil,
+		},
+		{
+			name: "exact match",
+			configurations: []svcsdktypes.Configuration{
+				{
+					Name: aws.String("abc"),
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abc/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abc/uuid-1"),
+		},
+		{
+			name: "longer name sharing a prefix does not match",
+			configurations: []svcsdktypes.Configuration{
+				{
+					Name: aws.String("abcd"),
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abcd/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+		{
+			name: "exact match found among other configurations",
+			configurations: []svcsdktypes.Configuration{
+				{
+					Name: aws.String("abcd"),
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abcd/uuid-1"),
+				},
+				{
+					Name: aws.String("abc"),
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abc/uuid-2"),
+				},
+			},
+			lookup: "abc",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/abc/uuid-2"),
+		},
+		{
+			name: "name differing only by case does not match",
+			configurations: []svcsdktypes.Configuration{
+				{
+					Name: aws.String("ABC"),
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/ABC/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+		{
+			name: "nil configuration name is skipped",
+			configurations: []svcsdktypes.Configuration{
+				{
+					Name: nil,
+					Arn:  aws.String("arn:aws:kafka:us-west-2:123456789012:configuration/unknown/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findConfigurationARNByName(tt.configurations, tt.lookup)
+			if aws.ToString(got) != aws.ToString(tt.want) {
+				t.Errorf("findConfigurationARNByName() = %v, want %v",
+					aws.ToString(got), aws.ToString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/resource/configuration/resource.go
+++ b/pkg/resource/configuration/resource.go
@@ -97,6 +97,23 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+
+	// A configuration can be adopted either by its ARN or by its name. MSK
+	// configuration ARNs embed a service-generated UUID, so they are not knowable
+	// ahead of creation; adopting by name lets a GitOps workflow declare the
+	// resource without first discovering the ARN. sdkFind resolves the name to an
+	// ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}
+
 	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))

--- a/pkg/resource/configuration/sdk.go
+++ b/pkg/resource/configuration/sdk.go
@@ -62,6 +62,27 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+
+	// DescribeConfiguration is keyed on the configuration ARN, which is only
+	// known after creation. When the owner opted into adoption but no ARN is set
+	// -- an adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can proceed.
+	// Configuration names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		configurationARN, err := rm.getConfigurationARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if configurationARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*configurationARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}
+
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/pkg/resource/serverless_cluster/hooks.go
+++ b/pkg/resource/serverless_cluster/hooks.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/kafka-controller/pkg/adoption"
 	"github.com/aws-controllers-k8s/kafka-controller/pkg/sync"
 )
 
@@ -1102,4 +1103,68 @@ func int32OrNil(num *int64) *int32 {
 	}
 
 	return aws.Int32(int32(*num))
+}
+
+// shouldLookupARN returns true when the supplied resource needs its ARN
+// resolved from its name before a read can be attempted.
+func (rm *resourceManager) shouldLookupARN(r *resource) bool {
+	return adoption.ShouldLookupARN(r)
+}
+
+// getClusterARN looks up the ARN of the cluster named by the supplied
+// resource's Spec.Name. MSK cluster ARNs embed a service-generated UUID
+// (arn:aws:kafka:<region>:<account>:cluster/<name>/<uuid>-<n>), so they cannot
+// be constructed from the name alone and must be read back from the API.
+//
+// Cluster names are unique within an account and region, so at most one
+// cluster can match. Returns nil (without error) when no cluster matches,
+// which callers translate into ackerr.NotFound.
+func (rm *resourceManager) getClusterARN(
+	ctx context.Context,
+	r *resource,
+) (arn *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getClusterARN")
+	defer func() { exit(err) }()
+
+	// Spec.Name is required for create, but an adopted resource may be
+	// identified solely by its ARN, in which case there is nothing to look up.
+	if r.ko.Spec.Name == nil {
+		return nil, nil
+	}
+
+	input := &svcsdk.ListClustersV2Input{
+		ClusterNameFilter: r.ko.Spec.Name,
+	}
+
+	paginator := svcsdk.NewListClustersV2Paginator(rm.sdkapi, input)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListClustersV2", err)
+		if err != nil {
+			return nil, err
+		}
+		if arn := findClusterARNByName(resp.ClusterInfoList, *r.ko.Spec.Name); arn != nil {
+			return arn, nil
+		}
+	}
+	return nil, nil
+}
+
+// findClusterARNByName returns the ARN of the cluster named exactly name, or
+// nil if the supplied page holds no such cluster.
+func findClusterARNByName(
+	clusters []svcsdktypes.Cluster,
+	name string,
+) *string {
+	for _, c := range clusters {
+		// ClusterNameFilter is a prefix filter, so a filter of "abc" also
+		// returns a cluster named "abcd". This exact-match check is what makes
+		// the lookup correct.
+		if c.ClusterName == nil || *c.ClusterName != name {
+			continue
+		}
+		return c.ClusterArn
+	}
+	return nil
 }

--- a/pkg/resource/serverless_cluster/hooks_test.go
+++ b/pkg/resource/serverless_cluster/hooks_test.go
@@ -1,0 +1,116 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package serverless_cluster
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+func Test_findClusterARNByName(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters []svcsdktypes.Cluster
+		lookup   string
+		want     *string
+	}{
+		{
+			name:     "no clusters",
+			clusters: nil,
+			lookup:   "abc",
+			want:     nil,
+		},
+		{
+			name: "exact match",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: aws.String("abc"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abc/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abc/uuid-1"),
+		},
+		{
+			name: "longer name sharing the filter prefix does not match",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: aws.String("abcd"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abcd/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+		{
+			name: "exact match found among prefix matches",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: aws.String("abcd"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abcd/uuid-1"),
+				},
+				{
+					ClusterName: aws.String("abc"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abc/uuid-2"),
+				},
+			},
+			lookup: "abc",
+			want:   aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/abc/uuid-2"),
+		},
+		{
+			name: "shorter name than the filter does not match",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: aws.String("ab"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/ab/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+		{
+			name: "name differing only by case does not match",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: aws.String("ABC"),
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/ABC/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+		{
+			name: "nil cluster name is skipped",
+			clusters: []svcsdktypes.Cluster{
+				{
+					ClusterName: nil,
+					ClusterArn:  aws.String("arn:aws:kafka:us-west-2:123456789012:cluster/unknown/uuid-1"),
+				},
+			},
+			lookup: "abc",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findClusterARNByName(tt.clusters, tt.lookup)
+			if aws.ToString(got) != aws.ToString(tt.want) {
+				t.Errorf("findClusterARNByName() = %v, want %v",
+					aws.ToString(got), aws.ToString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/resource/serverless_cluster/resource.go
+++ b/pkg/resource/serverless_cluster/resource.go
@@ -97,6 +97,22 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}
+
 	resourceARN, ok := fields["arn"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))

--- a/pkg/resource/serverless_cluster/sdk.go
+++ b/pkg/resource/serverless_cluster/sdk.go
@@ -64,6 +64,27 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+
+	// DescribeClusterV2 is keyed on the cluster ARN, which is only known after
+	// creation. When the owner opted into adoption but no ARN is set -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}
+
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-14T19:40:07Z"
+	ACKGenerateVersion   = "v0.62.1-4-gd4aaca5"
+	ACKGenerateBuildDate = "2026-08-18T16:43:27Z"
 )

--- a/templates/hooks/cluster/pre_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/cluster/pre_populate_resource_from_annotation.go.tpl
@@ -1,0 +1,15 @@
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}

--- a/templates/hooks/cluster/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,20 @@
+
+	// DescribeCluster is keyed on the cluster ARN, which is only known after
+	// creation. When the owner opted into adoption but no ARN is set -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}

--- a/templates/hooks/configuration/pre_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/configuration/pre_populate_resource_from_annotation.go.tpl
@@ -1,0 +1,16 @@
+
+	// A configuration can be adopted either by its ARN or by its name. MSK
+	// configuration ARNs embed a service-generated UUID, so they are not knowable
+	// ahead of creation; adopting by name lets a GitOps workflow declare the
+	// resource without first discovering the ARN. sdkFind resolves the name to an
+	// ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}

--- a/templates/hooks/configuration/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/configuration/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,20 @@
+
+	// DescribeConfiguration is keyed on the configuration ARN, which is only
+	// known after creation. When the owner opted into adoption but no ARN is set
+	// -- an adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can proceed.
+	// Configuration names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		configurationARN, err := rm.getConfigurationARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if configurationARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*configurationARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}

--- a/templates/hooks/serverless_cluster/pre_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/serverless_cluster/pre_populate_resource_from_annotation.go.tpl
@@ -1,0 +1,15 @@
+
+	// A cluster can be adopted either by its ARN or by its name. MSK cluster
+	// ARNs embed a service-generated UUID, so they are not knowable ahead of
+	// creation; adopting by name lets a GitOps workflow declare the resource
+	// without first discovering the ARN. sdkFind resolves the name to an ARN.
+	//
+	// When "arn" is present we fall through to the generated handling below.
+	if _, ok := fields["arn"]; !ok {
+		name, ok := fields["name"]
+		if !ok {
+			return ackerrors.NewTerminalError(fmt.Errorf("required field missing: one of arn or name"))
+		}
+		r.ko.Spec.Name = &name
+		return nil
+	}

--- a/templates/hooks/serverless_cluster/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/serverless_cluster/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,20 @@
+
+	// DescribeClusterV2 is keyed on the cluster ARN, which is only known after
+	// creation. When the owner opted into adoption but no ARN is set -- an
+	// adoption by name, or an adopt-or-create with no adoption-fields
+	// annotation -- resolve the ARN from the name so the read below can
+	// proceed. Cluster names are unique per account and region.
+	if rm.shouldLookupARN(r) {
+		r = rm.concreteResource(r.DeepCopy())
+		clusterARN, err := rm.getClusterARN(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if clusterARN != nil {
+			if r.ko.Status.ACKResourceMetadata == nil {
+				r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			arn := ackv1alpha1.AWSResourceName(*clusterARN)
+			r.ko.Status.ACKResourceMetadata.ARN = &arn
+		}
+	}

--- a/test/e2e/resources/cluster_adopt_by_name.yaml
+++ b/test/e2e/resources/cluster_adopt_by_name.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: Cluster
+metadata:
+  name: $ADOPT_CR_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt
+    services.k8s.aws/adoption-fields: "$ADOPTION_FIELDS"
+    services.k8s.aws/read-only: "true"
+spec:
+  name: $CLUSTER_NAME
+  brokerNodeGroupInfo: {}
+  kafkaVersion: "3.9.x"
+  numberOfBrokerNodes: 2

--- a/test/e2e/resources/serverlesscluster_adopt_by_name.yaml
+++ b/test/e2e/resources/serverlesscluster_adopt_by_name.yaml
@@ -1,0 +1,8 @@
+apiVersion: kafka.services.k8s.aws/v1alpha1
+kind: ServerlessCluster
+metadata:
+  name: $ADOPT_CR_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt
+    services.k8s.aws/adoption-fields: "$ADOPTION_FIELDS"
+    services.k8s.aws/read-only: "true"

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -251,6 +251,50 @@ class TestCluster:
             actual=latest_tags,
         )
 
+        cluster_name = cr["spec"]["name"]
+        adopt_cr_name = random_suffix_name("ack-adopt-name", 24)
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["ADOPT_CR_NAME"] = adopt_cr_name
+        replacements["CLUSTER_NAME"] = cluster_name
+        replacements["ADOPTION_FIELDS"] = f'{{\\"name\\": \\"{cluster_name}\\"}}'
+
+        adopt_ref = k8s.CustomResourceReference(
+            CRD_GROUP,
+            CRD_VERSION,
+            CLUSTER_RESOURCE_PLURAL,
+            adopt_cr_name,
+            namespace="default",
+        )
+        k8s.create_custom_resource(
+            adopt_ref,
+            load_resource(
+                "cluster_adopt_by_name",
+                additional_replacements=replacements,
+            ),
+        )
+
+        try:
+            assert k8s.wait_resource_consumed_by_controller(adopt_ref) is not None
+            assert k8s.wait_on_condition(
+                adopt_ref,
+                "ACK.ResourceSynced",
+                "True",
+                wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+            )
+
+            adopted = k8s.get_resource(adopt_ref)
+            assert adopted["status"]["ackResourceMetadata"]["arn"] == cluster_arn
+            assert adopted["spec"]["name"] == cluster_name
+            assert adopted["status"]["state"] == "ACTIVE"
+        finally:
+            k8s.delete_custom_resource(
+                adopt_ref,
+                period_length=DELETE_WAIT_SECONDS,
+            )
+
+        assert cluster.get_by_arn(cluster_arn) is not None
+        condition.assert_synced(ref)
+
 
 @pytest.fixture(scope="module")
 def update_cluster():

--- a/test/e2e/tests/test_configuration.py
+++ b/test/e2e/tests/test_configuration.py
@@ -63,6 +63,58 @@ def simple_config():
         pass
 
 @pytest.fixture(scope="module")
+def adoption_by_name_config():
+    resource_name = random_suffix_name("my-config", 24)
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CONFIG_NAME"] = resource_name
+    replacements["DELETION_POLICY"] = "retain"
+
+    resource_data = load_resource(
+        "configuration_simple", additional_replacements=replacements
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CONFIG_RESOURCE_PLURAL,
+        resource_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+
+    try:
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_SECONDS,
+        )
+        cr = k8s.get_resource(ref)
+        arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+
+        replacements["ADOPTION_FIELDS"] = f'{{\\\"name\\\": \\\"{resource_name}\\\"}}'
+        resource_data = load_resource(
+            "configuration_adopt", additional_replacements=replacements
+        )
+
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+
+        yield (ref, cr, arn)
+    finally:
+        try:
+            k8s.delete_custom_resource(ref, DELETE_WAIT_SECONDS)
+        except:
+            pass
+
+
+@pytest.fixture(scope="module")
 def adoption_config():
     resource_name = random_suffix_name("my-config", 24)
     replacements = REPLACEMENT_VALUES.copy()
@@ -174,3 +226,20 @@ class TestConfiguration:
         assert "spec" in cr
         assert "serverProperties" in cr["spec"]
 
+
+    def test_adopt_by_name(self, adoption_by_name_config):
+        ref, _, arn = adoption_by_name_config
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=MODIFY_WAIT_SECONDS,
+        )
+
+        cr = k8s.get_resource(ref)
+        assert cr["status"]["ackResourceMetadata"]["arn"] == arn
+        assert cr["spec"]["serverProperties"] is not None
+
+        latest = get_by_arn(arn)
+        assert latest is not None
+        assert latest["Name"] == cr["spec"]["name"]

--- a/test/e2e/tests/test_serverless_cluster.py
+++ b/test/e2e/tests/test_serverless_cluster.py
@@ -286,6 +286,61 @@ class TestServerlessCluster:
             actual=latest_tags,
         )
 
+    def test_adopt_by_name(self, simple_provisioned_cluster):
+        ref, _ = simple_provisioned_cluster
+
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=CHECK_STATUS_WAIT_SECONDS,
+        )
+
+        cr = k8s.get_resource(ref)
+        cluster_arn = cr["status"]["ackResourceMetadata"]["arn"]
+        cluster_name = cr["spec"]["name"]
+
+        adopt_cr_name = random_suffix_name("ack-adopt-name", 24)
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["ADOPT_CR_NAME"] = adopt_cr_name
+        replacements["ADOPTION_FIELDS"] = f'{{\\"name\\": \\"{cluster_name}\\"}}'
+
+        adopt_ref = k8s.CustomResourceReference(
+            CRD_GROUP,
+            CRD_VERSION,
+            SERVERLESSCLUSTER_RESOURCE_PLURAL,
+            adopt_cr_name,
+            namespace="default",
+        )
+        k8s.create_custom_resource(
+            adopt_ref,
+            load_resource(
+                "serverlesscluster_adopt_by_name",
+                additional_replacements=replacements,
+            ),
+        )
+
+        try:
+            assert k8s.wait_resource_consumed_by_controller(adopt_ref) is not None
+            assert k8s.wait_on_condition(
+                adopt_ref,
+                "ACK.ResourceSynced",
+                "True",
+                wait_periods=MODIFY_WAIT_AFTER_SECONDS,
+            )
+
+            adopted = k8s.get_resource(adopt_ref)
+            assert adopted["status"]["ackResourceMetadata"]["arn"] == cluster_arn
+            assert adopted["spec"]["name"] == cluster_name
+        finally:
+            k8s.delete_custom_resource(
+                adopt_ref,
+                period_length=DELETE_WAIT_SECONDS,
+            )
+
+        assert serverlesscluster.get_by_arn(cluster_arn) is not None
+        condition.assert_synced(ref)
+
     def test_serverless_crud(self, simple_provisioned_cluster):
         ref, _ = simple_provisioned_cluster
 
@@ -338,6 +393,7 @@ class TestServerlessCluster:
             expected=desired_tags,
             actual=latest_tags,
         )
+
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Description of changes:
MSK cluster ARNs embed a service-generated UUID, so they cannot be known
before creation, which made GitOps-style adoption impractical. Adoption now
accepts {"name": "..."} in addition to {"arn": "..."}, and sdkFind resolves
a name to its ARN via ListClusters/ListClustersV2 when the ARN is absent --
so annotation-free adopt-or-create works too.

ClusterNameFilter is a prefix filter, so the resolved cluster name is
compared for exact equality; a filter of "abc" must not match "abcd".

Resolves aws-controllers-k8s/community#2943

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
